### PR TITLE
Fix build on Windows platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ suite from a local repository:
 $ mvn install
 ```
 
+If you do not have Git installed, you will need to skip the build number plugin phase, 
+otherwise an error will occur. 
+
+```sh
+$ mvn install -Dmaven.buildNumber.skip=true
+```
+
+
 The compiled JAR will be available at `target/ets-cdb10-0.2-SNAPSHOT-aio.jar`.
 For TEAM Engine, you will need `target/ets-cdb10-0.2-SNAPSHOT-ctl.zip` and `target/ets-cdb10-0.2-SNAPSHOT-deps.zip`.
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,8 @@
   <properties>
     <ets-code>cdb10</ets-code>
     <spec-version>1.0</spec-version>
+    <javadoc-plugin.version>2.10.4</javadoc-plugin.version>
+    <testng.javadoc.url>https://jitpack.io/com/github/cbeust/testng/master/javadoc</testng.javadoc.url>
   </properties>
 
   <dependencies>
@@ -85,12 +87,12 @@
     <plugins>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.3</version>
+        <version>${javadoc-plugin.version}</version>
         <configuration>
           <docfilessubdirs>true</docfilessubdirs>
           <show>package</show>
           <links>
-            <link>http://testng.org/javadocs/</link>
+            <link>${testng.javadoc.url}</link>
           </links>
         </configuration>
         <executions>
@@ -149,6 +151,32 @@
       </plugin>
     </plugins>
   </build>
+  
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>${javadoc-plugin.version}</version>
+        <reportSets>
+          <reportSet>
+            <id>default</id>
+            <configuration>
+              <docfilessubdirs>true</docfilessubdirs>
+              <show>package</show>
+              <links>
+                <link>${testng.javadoc.url}</link>
+              </links>
+            </configuration>
+            <reports>
+              <report>javadoc</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+    </plugins>
+  </reporting>
+  
   <dependencyManagement>
   	<dependencies>
   		<dependency>

--- a/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/LightsXxxXmlStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/LightsXxxXmlStructureTests.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.nio.file.*;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -47,6 +48,7 @@ public class LightsXxxXmlStructureTests extends Capability2Tests {
         }
 
         if (invalidFileNames.size() > 0) {
+        	Collections.sort(invalidFileNames);
             Assert.fail(String.format("%s are not a valid file name(s) the file name must start with 'Lights_', " +
                     "can only be a maximum of 32 characters and contain letters, numbers, " +
                     "underscores and dashes.", invalidFileNames.toString()));

--- a/src/test/java/org/opengis/cite/cdb10/TestFixture.java
+++ b/src/test/java/org/opengis/cite/cdb10/TestFixture.java
@@ -8,12 +8,10 @@ import org.junit.rules.ExpectedException;
 import org.testng.ISuite;
 import org.testng.ITestContext;
 
+import java.io.File;
 import java.io.IOException;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -48,18 +46,17 @@ public abstract class TestFixture<T extends CommonFixture> {
 
 	@After
 	public void cleanupTestCDB() throws IOException {
-		Files.walkFileTree(this.cdb_root, new SimpleFileVisitor<Path>() {
-			@Override
-			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-				Files.delete(file);
-				return FileVisitResult.CONTINUE;
-			}
+		deleteRecursive(this.cdb_root.toFile());
+	}
 
-			@Override
-			public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
-				Files.delete(dir);
-				return FileVisitResult.CONTINUE;
-			}
-		});
+	public boolean deleteRecursive(File path) {
+	    if (path.isDirectory()) {
+	        for (File file : path.listFiles()) {
+	            if (!deleteRecursive(file)) {
+	                return false;
+	            }
+	        }
+	    }
+	    return path.delete();
 	}
 }

--- a/src/test/java/org/opengis/cite/cdb10/metadataAndVersioning/VerifyLightsXxxXmlStructureTests.java
+++ b/src/test/java/org/opengis/cite/cdb10/metadataAndVersioning/VerifyLightsXxxXmlStructureTests.java
@@ -61,8 +61,8 @@ public class VerifyLightsXxxXmlStructureTests extends MetadataTestFixture<Lights
         Files.createFile(metadataFolder.resolve(Paths.get("Lights_123451234512345123451234512345_example1.xml")));
         Files.createFile(metadataFolder.resolve(Paths.get("Lights_123451234512345123451234512345_example2.xml")));
 
-        String expectedMessage = "[Lights_123451234512345123451234512345_example2.xml, " +
-                "Lights_123451234512345123451234512345_example1.xml] are not a valid file name(s) the file name must start with " +
+        String expectedMessage = "[Lights_123451234512345123451234512345_example1.xml, " +
+                "Lights_123451234512345123451234512345_example2.xml] are not a valid file name(s) the file name must start with " +
                 "'Lights_', can only be a maximum of 32 characters and contain letters, numbers, underscores and dashes.";
 
         expectedException.expect(AssertionError.class);


### PR DESCRIPTION
Building on Windows would fail as the JUnit test cleanup function would fail to recursively delete the testing directories it created.

These commits fix:

* Building JavaDoc failing due to broken JavaDocs URL
* JUnit cleanup function failure
* Sort order on error message regarding multiple invalid files causing JUnit test failure

I also added a note about building the project without Git installed, for users who download the ETS as a ZIP and build using JDK and Maven only.

I tested building the ETS on Windows 10 with JDK 10.0.2 and Maven 3.5.4, as well as MacOS 10.13.5 with JDK 10.0.1 and Maven 3.5.4.