### PR TITLE
Update test annotations with document references

### DIFF
--- a/src/main/java/org/opengis/cite/cdb10/cdbStructure/GTModelCMTStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/cdbStructure/GTModelCMTStructureTests.java
@@ -18,11 +18,10 @@ public class GTModelCMTStructureTests extends Capability1Tests {
 
 	/**
 	 * Validates that GTModelCMT filenames have valid codes/names.
-	 * Test based on Section 3.4.2, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.14, Test 51 - based on Section 3.4.2")
 	public void verifyCMTFile() throws IOException {
 		Path gtModelGeomPath = Paths.get(this.path, "GTModel", "505_GTModelCMT");
 

--- a/src/main/java/org/opengis/cite/cdb10/cdbStructure/GTModelDescriptorStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/cdbStructure/GTModelDescriptorStructureTests.java
@@ -18,11 +18,10 @@ public class GTModelDescriptorStructureTests extends Capability1Tests {
 	
 	/**
 	 * Validates that GTModelDescriptor filenames have valid codes/names.
-	 * Test based on Section 3.4.1, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.14, Test 48 - based on Section 3.4.1")
 	public void verifyDescriptorFile() throws IOException {
 		Path gtModelGeomPath = Paths.get(this.path, "GTModel", "503_GTModelDescriptor");
 

--- a/src/main/java/org/opengis/cite/cdb10/cdbStructure/GTModelGeometryStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/cdbStructure/GTModelGeometryStructureTests.java
@@ -19,11 +19,10 @@ public class GTModelGeometryStructureTests extends Capability1Tests {
 
 	/**
 	 * Validates that GTModelGeometry Entry filenames have valid codes/names.
-	 * Test based on Section 3.4.1, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.14, Test 46 - based on Section 3.4.1")
 	public void verifyGeometryEntryFile() throws IOException {
 		Path gtModelGeomPath = Paths.get(this.path, "GTModel", "500_GTModelGeometry");
 
@@ -84,11 +83,10 @@ public class GTModelGeometryStructureTests extends Capability1Tests {
 	
 	/**
 	 * Validates that GTModelGeometry LoD filenames have valid codes/names.
-	 * Test based on Section 3.4.1, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.14, Test 47 - based on Section 3.4.1")
 	public void verifyGeometryLoDFile() throws IOException {
 		Path gtModelGeomPath = Paths.get(this.path, "GTModel", "510_GTModelGeometry");
 

--- a/src/main/java/org/opengis/cite/cdb10/cdbStructure/GTModelInteriorDescriptorStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/cdbStructure/GTModelInteriorDescriptorStructureTests.java
@@ -18,11 +18,10 @@ public class GTModelInteriorDescriptorStructureTests extends Capability1Tests {
 	
 	/**
 	 * Validates that GTModelInteriorDescriptor filenames have valid codes/names.
-	 * Test based on Section 3.4.3, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.14, Test 53 - based on Section 3.4.3")
 	public void verifyInteriorDescriptorFile() throws IOException {
 		Path gtModelGeomPath = Paths.get(this.path, "GTModel", "508_GTModelInteriorDescriptor");
 

--- a/src/main/java/org/opengis/cite/cdb10/cdbStructure/GTModelInteriorGeometryStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/cdbStructure/GTModelInteriorGeometryStructureTests.java
@@ -19,11 +19,10 @@ public class GTModelInteriorGeometryStructureTests extends Capability1Tests {
 	
 	/**
 	 * Validates that GTModelInteriorGeometry filenames have valid codes/names.
-	 * Test based on Section 3.4.3, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.14, Test 52 - based on Section 3.4.3")
 	public void verifyInteriorGeometryFile() throws IOException {
 		Path gtModelInteriorGeomPath = Paths.get(this.path, "GTModel", "506_GTModelInteriorGeometry");
 

--- a/src/main/java/org/opengis/cite/cdb10/cdbStructure/GTModelInteriorMaterialStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/cdbStructure/GTModelInteriorMaterialStructureTests.java
@@ -17,11 +17,10 @@ import org.testng.annotations.Test;
 public class GTModelInteriorMaterialStructureTests extends Capability1Tests {
 	/**
 	 * Validates that GTModelInteriorMaterial filenames have valid codes/names.
-	 * Test based on Section 3.4.4, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.14, Test 55 - based on Section 3.4.4")
 	public void verifyModelInteriorMaterialFile() throws IOException {
 		Path gtModelGeomPath = Paths.get(this.path, "GTModel", "509_GTModelInteriorMaterial");
 

--- a/src/main/java/org/opengis/cite/cdb10/cdbStructure/GTModelInteriorTextureStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/cdbStructure/GTModelInteriorTextureStructureTests.java
@@ -17,11 +17,10 @@ import org.testng.annotations.Test;
 public class GTModelInteriorTextureStructureTests extends Capability1Tests {
 	/**
 	 * Validates that GTModelInteriorTexture filenames have valid codes/names.
-	 * Test based on Section 3.4.4, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.14, Test 54 - based on Section 3.4.4")
 	public void verifyModelInteriorTextureFile() throws IOException {
 		Path gtModelGeomPath = Paths.get(this.path, "GTModel", "507_GTModelInteriorTexture");
 

--- a/src/main/java/org/opengis/cite/cdb10/cdbStructure/GTModelMaterialStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/cdbStructure/GTModelMaterialStructureTests.java
@@ -17,11 +17,10 @@ import org.testng.annotations.Test;
 public class GTModelMaterialStructureTests extends Capability1Tests {
 	/**
 	 * Validates that GTModelMaterial filenames have valid codes/names.
-	 * Test based on Section 3.4.2, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.14, Test 50 - based on Section 3.4.2")
 	public void verifyModelMaterialFile() throws IOException {
 		Path gtModelGeomPath = Paths.get(this.path, "GTModel", "504_GTModelMaterial");
 

--- a/src/main/java/org/opengis/cite/cdb10/cdbStructure/GTModelSignatureStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/cdbStructure/GTModelSignatureStructureTests.java
@@ -19,11 +19,10 @@ public class GTModelSignatureStructureTests extends Capability1Tests {
 	
 	/**
 	 * Validates that GTModelSignature filenames have valid codes/names.
-	 * Test based on Section 3.4.5, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.14, Test 56 - based on Section 3.4.5")
 	public void verifyGeometrySignatureFile() throws IOException {
 		// 502 is not a typo — it is used for backwards compatibility 
 		// between CDB 3.1 and CDB 3.0, and with OGC CDB 1.0.

--- a/src/main/java/org/opengis/cite/cdb10/cdbStructure/GTModelStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/cdbStructure/GTModelStructureTests.java
@@ -18,12 +18,11 @@ import org.testng.annotations.Test;
 
 public class GTModelStructureTests extends Capability1Tests {
 	/**
-	 * Validates that GTModel directories have valid codes/names. 
-	 * Test based on Section 3.4.1, Volume 1, OGC CDB Core Standard (Version 1.0)
+	 * Validates that GTModel directories have valid codes/names.
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.14, Test 45 - based on Section 3.4.1")
 	public void verifyDataset() throws IOException {
 		Path gtModelsPath = Paths.get(this.path, "GTModel");
 
@@ -88,12 +87,10 @@ public class GTModelStructureTests extends Capability1Tests {
 	 * Level 3: Feature Sub-Category
 	 * Level 4: Feature Type
 	 * Level 5: LOD
-	 * 
-	 * Test based on Section 3.4.1/3.4.3/3.4.5, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.14, Test 46/47/48/52/53 - based on Section 3.4.1")
 	public void verifyCategory() throws IOException {
 		Path gtModelsPath = Paths.get(this.path, "GTModel");
 
@@ -163,12 +160,10 @@ public class GTModelStructureTests extends Capability1Tests {
 	 * Level 3: Feature Sub-Category
 	 * Level 4: Feature Type
 	 * Level 5: LOD
-	 * 
-	 * Test based on Section 3.4.1/3.4.3, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.14, Test 46/47/48/52/53 - based on Section 3.4.1")
 	public void verifySubcategory() throws IOException {
 		Path gtModelsPath = Paths.get(this.path, "GTModel");
 
@@ -242,12 +237,10 @@ public class GTModelStructureTests extends Capability1Tests {
 	 * Level 3: Feature Sub-Category
 	 * Level 4: Feature Type
 	 * Level 5: LOD
-	 * 
-	 * Test based on Section 3.4.1/3.4.3, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.14, Test 46/47/48/52/53 - based on Section 3.4.1")
 	public void verifyFeatureType() throws IOException {
 		Path gtModelsPath = Paths.get(this.path, "GTModel");
 
@@ -330,12 +323,10 @@ public class GTModelStructureTests extends Capability1Tests {
 	 * Level 3: Feature Sub-Category
 	 * Level 4: Feature Type
 	 * Level 5: LOD
-	 * 
-	 * Test based on Section 3.4.1/3.4.3, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.14, Test 46/47/48/52/53 - based on Section 3.4.1")
 	public void verifyLOD() throws IOException {
 		Path gtModelsPath = Paths.get(this.path, "GTModel");
 
@@ -386,12 +377,10 @@ public class GTModelStructureTests extends Capability1Tests {
 	 * Level 2: TNAM First Character
 	 * Level 3: TNAM Second Character
 	 * Level 4: Texture Name (TNAM)
-	 * 
-	 * Test based on Section 3.4.2/3.4.4, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.14, Test 49/50/51/54/55 - based on Section 3.4.2")
 	public void verifyTNAMPrefix() throws IOException {
 		Path gtModelsPath = Paths.get(this.path, "GTModel");
 
@@ -437,12 +426,10 @@ public class GTModelStructureTests extends Capability1Tests {
 	 * Level 2: TNAM First Character
 	 * Level 3: TNAM Second Character
 	 * Level 4: Texture Name (TNAM)
-	 * 
-	 * Test based on Section 3.4.2/3.4.4, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.14, Test 49/50/51/54/55 - based on Section 3.4.2")
 	public void verifyTNAMSecond() throws IOException {
 		Path gtModelsPath = Paths.get(this.path, "GTModel");
 
@@ -493,11 +480,9 @@ public class GTModelStructureTests extends Capability1Tests {
 	 * Level 3: TNAM Second Character
 	 * Level 4: Texture Name (TNAM)
 	 * 
-	 * Test based on Section 3.4.2/3.4.4, Volume 1, OGC CDB Core Standard (Version 1.0)
-	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.14, Test 49/50/51/54/55 - based on Section 3.4.2")
 	public void verifyTNAM() throws IOException {
 		Path gtModelsPath = Paths.get(this.path, "GTModel");
 

--- a/src/main/java/org/opengis/cite/cdb10/cdbStructure/GTModelTextureStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/cdbStructure/GTModelTextureStructureTests.java
@@ -17,11 +17,10 @@ import org.testng.annotations.Test;
 public class GTModelTextureStructureTests extends Capability1Tests {
 	/**
 	 * Validates that GTModelTexture filenames have valid codes/names.
-	 * Test based on Section 3.4.2, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.14, Test 49 - based on Section 3.4.2")
 	public void verifyModelTextureFile() throws IOException {
 		Path gtModelGeomPath = Paths.get(this.path, "GTModel", "511_GTModelTexture");
 

--- a/src/main/java/org/opengis/cite/cdb10/cdbStructure/MModelGeometryStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/cdbStructure/MModelGeometryStructureTests.java
@@ -17,11 +17,10 @@ import org.testng.annotations.Test;
 public class MModelGeometryStructureTests extends Capability1Tests {
 	/**
 	 * Validates that MModelGeometry DIS Entity Kind directories have valid codes/names.
-	 * Test based on Section 3.5.1, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.15, Test 58 - based on Section 3.5.1")
 	public void verifyDISEntityKind() throws IOException {
 		Path mmodelGeomPath = Paths.get(this.path, "MModel", "600_MModelGeometry");
 
@@ -40,11 +39,10 @@ public class MModelGeometryStructureTests extends Capability1Tests {
 
 	/**
 	 * Validates that MModelGeometry DIS Domain directories have valid codes/names.
-	 * Test based on Section 3.5.1, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.15, Test 58 - based on Section 3.5.1")
 	public void verifyDISDomain() throws IOException {
 		Path mmodelGeomPath = Paths.get(this.path, "MModel", "600_MModelGeometry");
 
@@ -67,11 +65,10 @@ public class MModelGeometryStructureTests extends Capability1Tests {
 
 	/**
 	 * Validates that MModelGeometry DIS Country directories have valid codes/names.
-	 * Test based on Section 3.5.1, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.15, Test 58 - based on Section 3.5.1")
 	public void verifyDISCountry() throws IOException {
 		Path mmodelGeomPath = Paths.get(this.path, "MModel", "600_MModelGeometry");
 
@@ -98,11 +95,10 @@ public class MModelGeometryStructureTests extends Capability1Tests {
 
 	/**
 	 * Validates that MModelGeometry DIS Category directories have valid codes/names.
-	 * Test based on Section 3.5.1, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.15, Test 58 - based on Section 3.5.1")
 	public void verifyDISCategory() throws IOException {
 		Path mmodelGeomPath = Paths.get(this.path, "MModel", "600_MModelGeometry");
 
@@ -133,11 +129,10 @@ public class MModelGeometryStructureTests extends Capability1Tests {
 
 	/**
 	 * Validates that MModelGeometry DIS Entity directories have valid codes/names.
-	 * Test based on Section 3.5.1, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.15, Test 58 - based on Section 3.5.1")
 	public void verifyDISEntity() throws IOException {
 		Path mmodelGeomPath = Paths.get(this.path, "MModel", "600_MModelGeometry");
 
@@ -173,11 +168,10 @@ public class MModelGeometryStructureTests extends Capability1Tests {
 
 	/**
 	 * Validates that MModelGeometry filenames have valid codes/names.
-	 * Test based on Section 3.5.1, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.15, Test 58 - based on Section 3.5.1")
 	public void verifyFile() throws IOException {
 		Path mmodelGeomPath = Paths.get(this.path, "MModel", "600_MModelGeometry");
 

--- a/src/main/java/org/opengis/cite/cdb10/cdbStructure/MModelSignatureStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/cdbStructure/MModelSignatureStructureTests.java
@@ -18,11 +18,10 @@ import org.testng.annotations.Test;
 public class MModelSignatureStructureTests extends Capability1Tests {
 	/**
 	 * Validates that MModelSignature DIS Entity Kind directories have valid codes/names.
-	 * Test based on Section 3.5.1, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.15, Test 63 - based on Section 3.5.1")
 	public void verifyDISEntityKind() throws IOException {
 		Path mmsPath = Paths.get(this.path, "MModel", "606_MModelSignature");
 
@@ -41,11 +40,10 @@ public class MModelSignatureStructureTests extends Capability1Tests {
 
 	/**
 	 * Validates that MModelSignature DIS Domain directories have valid codes/names.
-	 * Test based on Section 3.5.1, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.15, Test 63 - based on Section 3.5.1")
 	public void verifyDISDomain() throws IOException {
 		Path mmsPath = Paths.get(this.path, "MModel", "606_MModelSignature");
 
@@ -68,11 +66,10 @@ public class MModelSignatureStructureTests extends Capability1Tests {
 
 	/**
 	 * Validates that MModelSignature DIS Country directories have valid codes/names.
-	 * Test based on Section 3.5.1, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.15, Test 63 - based on Section 3.5.1")
 	public void verifyDISCountry() throws IOException {
 		Path mmsPath = Paths.get(this.path, "MModel", "606_MModelSignature");
 
@@ -99,11 +96,10 @@ public class MModelSignatureStructureTests extends Capability1Tests {
 
 	/**
 	 * Validates that MModelSignature DIS Category directories have valid codes/names.
-	 * Test based on Section 3.5.1, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.15, Test 63 - based on Section 3.5.1")
 	public void verifyDISCategory() throws IOException {
 		Path mmsPath = Paths.get(this.path, "MModel", "606_MModelSignature");
 
@@ -134,11 +130,10 @@ public class MModelSignatureStructureTests extends Capability1Tests {
 
 	/**
 	 * Validates that MModelSignature DIS Entity directories have valid codes/names.
-	 * Test based on Section 3.5.1, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.15, Test 63 - based on Section 3.5.1")
 	public void verifyDISEntity() throws IOException {
 		Path mmsPath = Paths.get(this.path, "MModel", "606_MModelSignature");
 
@@ -173,11 +168,10 @@ public class MModelSignatureStructureTests extends Capability1Tests {
 
 	/**
 	 * Validates that MModelSignature LOD directories have valid names.
-	 * Test based on Section 3.5.1, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.15, Test 63 - based on Section 3.5.1")
 	public void verifyLOD() throws IOException {
 		Path mmsPath = Paths.get(this.path, "MModel", "606_MModelSignature");
 
@@ -216,11 +210,10 @@ public class MModelSignatureStructureTests extends Capability1Tests {
 
 	/**
 	 * Validates that MModelSignature filenames have valid codes/names.
-	 * Test based on Section 3.5.1, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.15, Test 63 - based on Section 3.5.1")
 	public void verifyFile() throws IOException {
 		Path mmsPath = Paths.get(this.path, "MModel", "606_MModelSignature");
 

--- a/src/main/java/org/opengis/cite/cdb10/cdbStructure/MModelStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/cdbStructure/MModelStructureTests.java
@@ -14,11 +14,10 @@ import org.testng.annotations.Test;
 public class MModelStructureTests extends Capability1Tests {
 	/**
 	 * Validates that MModel directories have valid codes/names.
-	 * Test based on Section 3.5.1, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.15, Test 57 - based on Section 3.5.1")
 	public void verifyDataset() throws IOException {
 		Path mmPath = Paths.get(this.path, "MModel");
 

--- a/src/main/java/org/opengis/cite/cdb10/cdbStructure/MModelTextureStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/cdbStructure/MModelTextureStructureTests.java
@@ -20,7 +20,7 @@ public class MModelTextureStructureTests extends Capability1Tests {
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.15, Test 60 - based on Section 3.5.2")
 	public void verifyTNAMPrefix() throws IOException {
 		Path mmtPath = Paths.get(this.path, "MModel", "601_MModelTexture");
 
@@ -50,7 +50,7 @@ public class MModelTextureStructureTests extends Capability1Tests {
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.15, Test 60 - based on Section 3.5.2")
 	public void verifyTNAMSecond() throws IOException {
 		Path mmtPath = Paths.get(this.path, "MModel", "601_MModelTexture");
 
@@ -84,7 +84,7 @@ public class MModelTextureStructureTests extends Capability1Tests {
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.15, Test 60 - based on Section 3.5.2")
 	public void verifyTNAM() throws IOException {
 		Path mmtPath = Paths.get(this.path, "MModel", "601_MModelTexture");
 
@@ -136,7 +136,7 @@ public class MModelTextureStructureTests extends Capability1Tests {
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.15, Test 60 - based on Section 3.5.2")
 	public void verifyFile() throws IOException {
 		Path mmtPath = Paths.get(this.path, "MModel", "601_MModelTexture");
 

--- a/src/main/java/org/opengis/cite/cdb10/cdbStructure/NavigationLibraryStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/cdbStructure/NavigationLibraryStructureTests.java
@@ -17,10 +17,9 @@ import org.testng.annotations.Test;
 public class NavigationLibraryStructureTests extends Capability1Tests {
 	/**
 	 * Validate the Navigation datasets.
-	 * Test based on Section 3.7, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.18, Test 73 - based on Section 3.7")
 	public void verifyDatasets() throws IOException {
 		Path navPath = Paths.get(this.path, "Navigation");
 
@@ -59,11 +58,10 @@ public class NavigationLibraryStructureTests extends Capability1Tests {
 
 	/**
 	 * Validates that Navigation filenames have valid codes/names.
-	 * Test based on Section 3.7, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.18, Test 73 - based on Section 3.7")
 	public void verifyFile() throws IOException {
 		Path navPath = Paths.get(this.path, "Navigation", "400_NavData");
 

--- a/src/main/java/org/opengis/cite/cdb10/cdbStructure/RootStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/cdbStructure/RootStructureTests.java
@@ -13,17 +13,15 @@ import org.testng.annotations.Test;
 
 /**
  * File/directory structure tests for the root of the CDB directory
- * @author jpbadger
- *
  */
 public class RootStructureTests extends Capability1Tests {
 	/**
 	 * Validate the contents of the root directory of the CDB, checking for stray
 	 * files or directories not on the allowed list.
-	 * Test based on Section 3.1, Volume 1, OGC CDB Core Standard (Version 1.0)
+	 * 
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.18, Test 29 - based on Section 3.1")
 	public void verifyRootContents() throws IOException {
 		ArrayList<String> errors = new ArrayList<String>();
 		ArrayList<String> permittedRootDirectories = new ArrayList<String>(

--- a/src/main/java/org/opengis/cite/cdb10/cdbStructure/TilesStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/cdbStructure/TilesStructureTests.java
@@ -18,8 +18,6 @@ import org.testng.annotations.Test;
 
 /**
  * File/directory structure tests for the Tiles directory of the CDB
- * @author jpbadger
- *
  */
 public class TilesStructureTests extends Capability1Tests {
 
@@ -44,11 +42,10 @@ public class TilesStructureTests extends Capability1Tests {
 
 	/**
 	 * Validates that latitude geocell directories start with "S" or "N".
-	 * Test based on Section 3.6, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.16, Test 65 - based on Section 3.6")
 	public void verifyGeocellLatitudeDirNamePrefix() throws IOException {
 		Path tilesPath = Paths.get(this.path, "Tiles");
 
@@ -72,11 +69,10 @@ public class TilesStructureTests extends Capability1Tests {
 	/**
 	 * Validates that latitude geocell directories end with a valid slice latitude.
 	 * latitudes should be zero-padded to 2 width.
-	 * Test based on Section 3.6, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.16, Test 65 - based on Section 3.6")
 	public void verifyGeocellLatitudeDirNameSlice() throws IOException {
 		Path tilesPath = Paths.get(this.path, "Tiles");
 
@@ -119,11 +115,10 @@ public class TilesStructureTests extends Capability1Tests {
 
 	/**
 	 * Validates that longitude geocell directories start with "E" or "W".
-	 * Test based on Section 3.6, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.16, Test 66 - based on Section 3.6")
 	public void verifyGeocellLongitudeDirNamePrefix() throws IOException {
 		Path tilesPath = Paths.get(this.path, "Tiles");
 
@@ -153,11 +148,10 @@ public class TilesStructureTests extends Capability1Tests {
 	/**
 	 * Validates that longitude geocell directories end with a valid slice longitude.
 	 * longitudes should be zero-padded to 3 width.
-	 * Test based on Section 3.6, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.16, Test 66 - based on Section 3.6")
 	public void verifyGeocellLongitudeDirNameSlice() throws IOException {
 		Path tilesPath = Paths.get(this.path, "Tiles");
 
@@ -231,11 +225,10 @@ public class TilesStructureTests extends Capability1Tests {
 
 	/**
 	 * Validates that dataset directories begin with a 3-digit prefix.
-	 * Test based on Section 3.6, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, Section 3.6.2.3")
 	public void verifyDatasetPrefix() throws IOException {
 		Path tilesPath = Paths.get(this.path, "Tiles");
 
@@ -281,11 +274,10 @@ public class TilesStructureTests extends Capability1Tests {
 
 	/**
 	 * Validates that dataset directories prefix code and name match and are valid values.
-	 * Test based on Section 3.6, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, Section 3.6.2.3")
 	public void verifyDatasetCodeName() throws IOException {
 		Path tilesPath = Paths.get(this.path, "Tiles");
 
@@ -347,11 +339,10 @@ public class TilesStructureTests extends Capability1Tests {
 
 	/**
 	 * Validates that LOD directories have valid names.
-	 * Test based on Section 3.6, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, Section 3.6.2.4")
 	public void verifyLODName() throws IOException {
 		Path tilesPath = Paths.get(this.path, "Tiles");
 
@@ -385,11 +376,10 @@ public class TilesStructureTests extends Capability1Tests {
 
 	/**
 	 * Validates that UREF directories have valid names and are in a valid range for the LOD.
-	 * Test based on Section 3.6, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, A.1.16, Test 67 - based on Section 3.6")
 	public void verifyUREFName() throws IOException {
 		Path tilesPath = Paths.get(this.path, "Tiles");
 
@@ -445,11 +435,10 @@ public class TilesStructureTests extends Capability1Tests {
 
 	/**
 	 * Validates that tiled dataset files have valid names.
-	 * Test based on Section 3.6, Volume 1, OGC CDB Core Standard (Version 1.0)
 	 *
 	 * @throws IOException DirectoryStream error
 	 */
-	@Test
+	@Test(description = "OGC 15-113r5, Section 3.6.2")
 	public void verifyDatasetFileName() throws IOException {
 		Path tilesPath = Paths.get(this.path, "Tiles");
 

--- a/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/CDBAttributesXmlStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/CDBAttributesXmlStructureTests.java
@@ -30,7 +30,7 @@ public class CDBAttributesXmlStructureTests extends Capability2Tests {
 		return Files.exists(this.cdbAttributes.getXmlFilePath());
 	}
 
-    @Test
+    @Test(description = "OGC 15-113r5, A.1.19, Test 76")
     public void verifyCDBAttributesXmlAgainstSchema() throws IOException, SAXException {
     	this.loadXmlFile();
     	if (!this.xmlFileExists()) { return; }
@@ -45,7 +45,7 @@ public class CDBAttributesXmlStructureTests extends Capability2Tests {
         		" does not validate against its XML Schema file. Errors: " + errors);
     }
 
-    @Test
+    @Test(description = "OGC 15-113r5, A.1.19, Test 77")
     public void verifyCDBAttributesXmlCodeIsAnInteger() {
     	this.loadXmlFile();
     	if (!this.xmlFileExists()) { return; }
@@ -71,7 +71,7 @@ public class CDBAttributesXmlStructureTests extends Capability2Tests {
         }
     }
 
-    @Test
+    @Test(description = "OGC 15-113r5, A.1.19, Test 77")
     public void verifyCDBAttributesXmlSymbolIsUnique() {
     	this.loadXmlFile();
     	if (!this.xmlFileExists()) { return; }
@@ -92,7 +92,7 @@ public class CDBAttributesXmlStructureTests extends Capability2Tests {
         }
     }
 
-    @Test
+    @Test(description = "OGC 15-113r5, A.1.19, Test 77")
     public void verifyCDBAttributesXmlValueHasAValidType() {
     	this.loadXmlFile();
     	if (!this.xmlFileExists()) { return; }
@@ -114,7 +114,7 @@ public class CDBAttributesXmlStructureTests extends Capability2Tests {
         }
     }
 
-    @Test
+    @Test(description = "OGC 15-113r5, A.1.19, Test 78")
     public void verifyCDBAttributesXmlScalerCodeIsValid() {
     	this.loadXmlFile();
     	if (!this.xmlFileExists()) { return; }
@@ -134,7 +134,7 @@ public class CDBAttributesXmlStructureTests extends Capability2Tests {
         }
     }
 
-    @Test
+    @Test(description = "OGC 15-113r5, A.1.19, Test 79")
     public void verifyCDBAttributesXmlUnitCodeIsValid() {
     	this.loadXmlFile();
     	if (!this.xmlFileExists()) { return; }

--- a/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/ConfigurationXmlStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/ConfigurationXmlStructureTests.java
@@ -23,7 +23,7 @@ public class ConfigurationXmlStructureTests extends Capability2Tests {
 		return Files.exists(this.configuration.getXmlFilePath());
 	}
 
-    @Test
+    @Test(description = "OGC 15-113r5, A.1.19, Test 76")
     public void verifyConfigurationXmlAgainstSchema() throws IOException, SAXException {
         this.loadXmlFile();
         if (!this.xmlFileExists()) { return; }

--- a/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/DefaultsXmlStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/DefaultsXmlStructureTests.java
@@ -41,7 +41,7 @@ public class DefaultsXmlStructureTests extends Capability2Tests {
         return names;
     }
 
-    @Test
+    @Test(description = "OGC 15-113r5, A.1.19, Test 76")
     public void verifyDefaultsXmlAgainstSchema() throws IOException, SAXException {
         this.loadXmlFile();
         if (!this.xmlFileExists()) { return; }
@@ -51,7 +51,7 @@ public class DefaultsXmlStructureTests extends Capability2Tests {
         		" does not validate against its XML Schema file. Errors: " + errors);
     }
 
-    @Test
+    @Test(description = "OGC 15-113r5, A.1.19, Test 77")
     public void verifyDefaultsXmlElementR_W_TypeHasValidValues() {
     	this.loadXmlFile();
     	if (!this.xmlFileExists()) { return; }
@@ -73,7 +73,7 @@ public class DefaultsXmlStructureTests extends Capability2Tests {
         }
     }
 
-    @Test
+    @Test(description = "OGC 15-113r5, A.1.19, Test 77")
     public void verifyDefaultsXmlNameIsUniqueForEachDataset() {
     	this.loadXmlFile();
     	if (!this.xmlFileExists()) { return; }
@@ -98,7 +98,7 @@ public class DefaultsXmlStructureTests extends Capability2Tests {
         }
     }
 
-    @Test
+    @Test(description = "OGC 15-113r5, A.1.19, Test 77")
     public void verifyDefaultsXmlElementTypeHasValidValue() {
     	this.loadXmlFile();
     	if (!this.xmlFileExists()) { return; }

--- a/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/GeomaticsAttributesXmlStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/GeomaticsAttributesXmlStructureTests.java
@@ -23,7 +23,7 @@ public class GeomaticsAttributesXmlStructureTests extends Capability2Tests {
 		return Files.exists(this.geomaticsAttributes.getXmlFilePath());
 	}
 
-    @Test
+    @Test(description = "OGC 15-113r5, Section 3.1.1")
     public void verifyGeomaticsAttributesXsdFileExists() {
         this.loadXmlFile();
         if (!this.xmlFileExists()) { return; }
@@ -32,7 +32,7 @@ public class GeomaticsAttributesXmlStructureTests extends Capability2Tests {
 				String.format("Metadata directory should contain %s file.", geomaticsAttributes.getXsdFileName()));
     }
 
-    @Test
+    @Test(description = "OGC 15-113r5, A.1.19, Test 77")
     public void verifyGeomaticsAttributesXmlAgainstSchema() throws IOException, SAXException {
         this.loadXmlFile();
         if (!this.xmlFileExists()) { return; }

--- a/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/LightsXmlStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/LightsXmlStructureTests.java
@@ -28,7 +28,7 @@ public class LightsXmlStructureTests extends Capability2Tests {
 		return Files.exists(this.lights.getXmlFilePath());
 	}
 
-    @Test
+    @Test(description = "OGC 15-113r5, A.1.19, Test 76")
     public void verifyLightsXmlFileAgainstSchema() throws IOException, SAXException {
         this.loadXmlFile();
         if (!this.xmlFileExists()) { return; }
@@ -38,7 +38,7 @@ public class LightsXmlStructureTests extends Capability2Tests {
         		" does not validate against its XML Schema file. Errors: " + errors);
     }
 
-    @Test
+    @Test(description = "OGC 15-113r5, A.1.19, Test 77")
     public void verifyLightsXmlHasUniqueCodes() {
         this.loadXmlFile();
         if (!this.xmlFileExists()) { return; }
@@ -58,7 +58,7 @@ public class LightsXmlStructureTests extends Capability2Tests {
         }
     }
 
-    @Test
+    @Test(description = "OGC 15-113r5, A.1.19, Test 77")
     public void verifyLightsXmlCodesAreWithinRange() {
         this.loadXmlFile();
         if (!this.xmlFileExists()) { return; }

--- a/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/LightsXxxXmlStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/LightsXxxXmlStructureTests.java
@@ -16,7 +16,6 @@ import java.util.List;
 import org.opengis.cite.cdb10.util.SchemaValidatorErrorHandler;
 import org.opengis.cite.cdb10.util.XMLUtils;
 import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -29,14 +28,7 @@ public class LightsXxxXmlStructureTests extends Capability2Tests {
 
     private static final List<String> DIRECTIONALITY_VALUES = Arrays.asList("Omnidirectional", "Directional", "Bidirectional");
 
-    @Test
-    public void verifyLights_XxxXmlFileExists() {
-        for (File xmlFile : getCustomLightsXmlFiles()) {
-            Assert.assertTrue(Files.exists(Paths.get(path, "Metadata", xmlFile.getName())), "Optional file.");
-        }
-    }
-
-    @Test
+    @Test(description = "OGC 15-113r5, A.1.6, Test 18")
     public void verifyLightsXmlFileNameIsValid() {
         ArrayList<String> invalidFileNames = new ArrayList<>();
 
@@ -54,15 +46,15 @@ public class LightsXxxXmlStructureTests extends Capability2Tests {
         }
     }
 
-    @Test
-    public void verifyLightsTuningXsdFFileExists() {
+    @Test(description = "OGC 15-113r5, A.1.6, Test 18")
+    public void verifyLightsTuningXsdFileExists() {
     	if (getCustomLightsXmlFiles().size() > 0) {
     		Assert.assertTrue(Files.exists(Paths.get(path, "Metadata", "Schema", "Lights_Tuning.xsd")),
                     "If a custom Lights_xxx.xml exists there should be Lights_Tuning.xsd in the Schema folder.");
     	}
     }
 
-    @Test
+    @Test(description = "OGC 15-113r5, A.1.19, Test 76")
     public void verifyLightsXxxXmlAgainstSchema() throws IOException, SAXException {
         for (File xmlFile : getCustomLightsXmlFiles()) {
             File xsdFile = Paths.get(path, "Metadata", "Schema", "Lights_Tuning.xsd").toFile();
@@ -75,7 +67,7 @@ public class LightsXxxXmlStructureTests extends Capability2Tests {
         }
     }
 
-    @Test
+    @Test(description = "OGC 15-113r5, A.1.19, Test 77")
     public void verifyLightsXxxXmlDirectionalityValueIsValid() {
         for (File xmlFile : getCustomLightsXmlFiles()) {
             ArrayList<String> directionalityValues = getDirectionalityValues(xmlFile);
@@ -88,7 +80,7 @@ public class LightsXxxXmlStructureTests extends Capability2Tests {
         }
     }
 
-    @Test
+    @Test(description = "OGC 15-113r5, A.1.19, Test 77")
     public void verifyLightsXxxXmlElementIntensityIsInRange() {
         for (File xmlFile : getCustomLightsXmlFiles()) {
             ArrayList<String> invalidIntensityValues = getInvalidPercentageValues(xmlFile, "//Intensity");
@@ -99,7 +91,7 @@ public class LightsXxxXmlStructureTests extends Capability2Tests {
         }
     }
 
-    @Test
+    @Test(description = "OGC 15-113r5, A.1.19, Test 77")
     public void verifyLightsXxxXmlElementResidualIntensityIsInRange() {
         for (File xmlFile : getCustomLightsXmlFiles()) {
             ArrayList<String> invalidResidualIntensityValues = getInvalidPercentageValues(xmlFile, "//Residual_Intensity");
@@ -110,7 +102,7 @@ public class LightsXxxXmlStructureTests extends Capability2Tests {
         }
     }
 
-    @Test
+    @Test(description = "OGC 15-113r5, A.1.19, Test 77")
     public void verifyLightsXxxXmlElementDuty_CycleIsInRange() {
         for (File xmlFile : getCustomLightsXmlFiles()) {
             ArrayList<String> invalidResidualIntensityValues = getInvalidPercentageValues(xmlFile, "//Duty_Cycle");
@@ -121,7 +113,7 @@ public class LightsXxxXmlStructureTests extends Capability2Tests {
         }
     }
 
-    @Test
+    @Test(description = "OGC 15-113r5, A.1.19, Test 77")
     public void verifyLightsXxxXmlFrequencyValueIsValid() {
         for (File xmlFile : getCustomLightsXmlFiles()) {
             ArrayList<String> invalidFrequencyValues = getInvalidFrequencyValues(xmlFile);
@@ -132,7 +124,7 @@ public class LightsXxxXmlStructureTests extends Capability2Tests {
         }
     }
 
-    @Test
+    @Test(description = "OGC 15-113r5, A.1.19, Test 77")
     public void verifyLightsXxxXmlColorIsInRange() {
         for (File xmlFile : getCustomLightsXmlFiles()) {
             ArrayList<String> invalidColorValues = getInvalidColorValues(xmlFile);

--- a/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/MaterialsXmlStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/MaterialsXmlStructureTests.java
@@ -40,7 +40,13 @@ public class MaterialsXmlStructureTests extends Capability2Tests {
         return nameValues;
     }
 
-    @Test
+    /** If the Materials XML and Schema files exist, then verify the
+     * XML against the schema.
+     * 
+     * @throws IOException Error reading XML or Schema file
+     * @throws SAXException Error parsing XML or Schema file
+     */
+    @Test(description = "OGC 15-113r5, A.1.19, Test 76")
     public void verifyMaterialsXmlAgainstSchema() throws IOException, SAXException {
         this.loadXmlFile();
         if (!this.xmlFileExists()) { return; }
@@ -50,7 +56,7 @@ public class MaterialsXmlStructureTests extends Capability2Tests {
         		" does not validate against its XML Schema file. Errors: " + errors);
     }
 
-    @Test
+    @Test(description = "OGC 15-113r5, A.1.19, Test 77")
     public void verifyMaterialsXmlElementNameIsUnique() {
         this.loadXmlFile();
         if (!this.xmlFileExists()) { return; }
@@ -59,20 +65,20 @@ public class MaterialsXmlStructureTests extends Capability2Tests {
         
         for (String name : names) {
             Assert.assertEquals(Collections.frequency(names, name), 1,
-                    String.format("Materials.xml element Name should be unique. '%s' is not unique.", name));
+                    String.format("Materials.xml element \"<Name>\" should be unique. '%s' is not unique.", name));
         }
     }
 
-    @Test
+    @Test(description = "OGC 15-113r5, A.1.19, Test 76")
     public void verifyMaterialsXmlAllBaseMaterialElementsHaveAChildNodeName() {
     	this.loadXmlFile();
     	if (!this.xmlFileExists()) { return; }
     	
         NodeList baseMaterialNodes = XMLUtils.getNodeList("//Base_Material[not(Name)]", materials.getXmlFilePath());
-        Assert.assertEquals(baseMaterialNodes.getLength(), 0, "Materials.xml element Base_Material requires a child element Name.");
+        Assert.assertEquals(baseMaterialNodes.getLength(), 0, "Materials.xml element \"<Base_Material>\" requires a child element \"<Name>\".");
     }
 
-    @Test
+    @Test(description = "OGC 15-113r5, A.1.19, Test 76")
     public void verifyMaterialsXmlBaseMaterialNameIsValid() {
         this.loadXmlFile();
         if (!this.xmlFileExists()) { return; }
@@ -88,8 +94,8 @@ public class MaterialsXmlStructureTests extends Capability2Tests {
         }
 
         Assert.assertEquals(invalidNames.size(), 0,
-                String.format("Materials.xml element Name is always in format \"BM__*\", " +
+                String.format("Materials.xml element \"<Name>\" is always in format \"BM__*\", " +
                         "has a maximum of 32 characters, and can only contain letters, digits, " +
-                        "underscores, and hyphens. %s do not conform", invalidNames.toString()));
+                        "underscores, and hyphens. %s does not conform.", invalidNames.toString()));
     }
 }

--- a/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/MetadataStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/MetadataStructureTests.java
@@ -17,7 +17,12 @@ import java.util.List;
  */
 public class MetadataStructureTests extends CommonFixture {
 
-    @Test
+	/**
+	 * Verify the allowable contents of the Metadata directory.
+	 * 
+	 * @throws IOException Error reading from CDB
+	 */
+    @Test(description = "OGC 15-113r5, Section 5.1")
     public void verifyMetaDataFoldersExist() throws IOException {
         Assert.assertTrue(Files.exists(Paths.get(path, "Metadata", "Schema")), "Metadata should contain Schema folder.");
         Assert.assertTrue(Files.exists(Paths.get(path, "Metadata", "Stylesheet")), "Metadata should contain Stylesheet folder.");
@@ -48,9 +53,10 @@ public class MetadataStructureTests extends CommonFixture {
      * OpenFlight_Model_Extensions.xsd
      * Vector_Attributes.xsd
      * Version.xsd
+     * 
      * @throws IOException Error when loading filesystem
      */
-    @Test
+    @Test(description = "OGC 15-113r5, Section 1.4.2")
     public void verifyContentsOfSchemaFolder() throws IOException {
         List<String> REQUIRED_FILES = Arrays.asList("Base_Material_Table.xsd",
                 "Composite_Material_Table.xsd",

--- a/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/ModelComponentsXmlStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/ModelComponentsXmlStructureTests.java
@@ -23,7 +23,13 @@ public class ModelComponentsXmlStructureTests extends Capability2Tests {
 		return Files.exists(this.modelComponents.getXmlFilePath());
 	}
 
-    @Test
+    /** If the Model Components XML and Schema files exist, then verify the
+     * XML against the schema.
+     * 
+     * @throws IOException Error reading XML or Schema file
+     * @throws SAXException Error parsing XML or Schema file
+     */
+    @Test(description = "OGC 15-113r5, A.1.19, Test 76")
     public void verifyModelComponentsXmlAgainstSchema() throws IOException, SAXException {
         this.loadXmlFile();
         if (!this.xmlFileExists()) { return; }

--- a/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/VendorAttributesXmlStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/VendorAttributesXmlStructureTests.java
@@ -23,7 +23,11 @@ public class VendorAttributesXmlStructureTests extends Capability2Tests {
 		return Files.exists(this.vendorAttributes.getXmlFilePath());
 	}
 
-    @Test
+	/**
+	 * Verify that the schema file exists for a Vendor Attributes XML file.
+	 * If no Vendor Attributes XML file exists, then this test is skipped.
+	 */
+    @Test(description = "OGC 15-113r5, Section 3.1.1")
     public void verifyVendorAttributesXsdFileExists() {
         this.loadXmlFile();
         if (!this.xmlFileExists()) { return; }
@@ -32,7 +36,13 @@ public class VendorAttributesXmlStructureTests extends Capability2Tests {
 				String.format("Metadata directory should contain %s file.", vendorAttributes.getXsdFileName()));
     }
 
-    @Test
+    /** If the Vendor Attributes XML and Schema files exist, then verify the
+     * XML against the schema.
+     * 
+     * @throws IOException Error reading XML or Schema file
+     * @throws SAXException Error parsing XML or Schema file
+     */
+    @Test(description = "OGC 15-113r5, A.1.19, Test 76")
     public void verifyVendorAttributesXmlAgainstSchema() throws IOException, SAXException {
         this.loadXmlFile();
         if (!this.xmlFileExists()) { return; }

--- a/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/VersionXmlStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/VersionXmlStructureTests.java
@@ -24,14 +24,23 @@ public class VersionXmlStructureTests extends Capability2Tests {
 		this.version = new VersionXml(path);
 	}
 
-    @Test
+	/**
+	 * Check that Version.xml exists.
+	 */
+    @Test(description = "OGC 15-113r5, A.1.9, Test 33")
     public void verifyVersionXmlFileExists() {
         this.loadXmlFile();
     	Assert.assertTrue(version.xmlFileExists(),
     			String.format("Metadata directory should contain %s file.", version.getXmlFileName()));
     }
 
-    @Test
+    /**
+     * Verify Version.xml against Version.xsd.
+     * 
+     * @throws IOException Error reading XML or XSD file
+     * @throws SAXException Error parsing XML or XSD file
+     */
+    @Test(description = "OGC 15-113r5, A.1.19, Test 76")
     public void verifyVersionXmlAgainstSchema() throws IOException, SAXException {
         this.loadXmlFile();
         String errors = version.schemaValidationErrors();
@@ -39,7 +48,10 @@ public class VersionXmlStructureTests extends Capability2Tests {
         		" does not validate against its XML Schema file. Errors: " + errors);
     }
 
-    @Test
+    /**
+     * Check for "<Specification>" element in Version.xml.
+     */
+    @Test(description = "OGC 15-113r5, A.1.19, Test 76")
     public void verifyVersionXmlHasSpecificationElement() {
     	this.loadXmlFile();
         NodeList nodeList = XMLUtils.getNodeList("//Specification", version.getXmlFilePath());
@@ -49,7 +61,11 @@ public class VersionXmlStructureTests extends Capability2Tests {
         }
     }
 
-    @Test
+    /**
+     * Check that the "<Specification>" element has valid values for the
+     * "version" attribute.
+     */
+    @Test(description = "OGC 15-113r5, A.1.19, Test 77")
     public void verifyVersionXmlSpecificationVersionIsValid() {
     	this.loadXmlFile();
         NodeList nodeList = XMLUtils.getNodeList("//Specification", version.getXmlFilePath());

--- a/src/test/java/org/opengis/cite/cdb10/metadataAndVersioning/VerifyLightsXxxXmlStructureTests.java
+++ b/src/test/java/org/opengis/cite/cdb10/metadataAndVersioning/VerifyLightsXxxXmlStructureTests.java
@@ -83,34 +83,6 @@ public class VerifyLightsXxxXmlStructureTests extends MetadataTestFixture<Lights
     }
 
     @Test
-    public void verifyLightsTuningXsdFileExists_DoesNotExist() throws IOException {
-        //setup
-        Files.createFile(metadataFolder.resolve(Paths.get("Lights_Client.xml")));
-
-        expectedException.expect(AssertionError.class);
-        expectedException.expectMessage("If a custom Lights_xxx.xml exists there should be Lights_Tuning.xsd in the Schema folder.");
-
-        // execute
-        testSuite.verifyLightsTuningXsdFFileExists();
-    }
-
-    @Test
-    public void verifyLightsTuningXsdFileExists_DoesExist() throws IOException {
-        // setup
-        Files.createFile(metadataFolder.resolve(Paths.get("Lights_Client.xml")));
-        Files.createFile(schemaFolder.resolve(Paths.get("Lights_Tuning.xsd")));
-
-        // execute
-        testSuite.verifyLightsTuningXsdFFileExists();
-    }
-
-    @Test
-    public void verifyLights_XxxXmlFileExists_DoesNotExist() throws IOException {
-        // execute
-        testSuite.verifyLights_XxxXmlFileExists();
-    }
-
-    @Test
     public void verifyLightsXxxXmlAgainstSchema_XmlIsValid() throws IOException, SAXException {
         // setup
         Files.copy(VALID_FILE, metadataFolder.resolve("Lights_Client.xml"), REPLACE_EXISTING);

--- a/src/test/java/org/opengis/cite/cdb10/metadataAndVersioning/VerifyMaterialsXmlStructureTests.java
+++ b/src/test/java/org/opengis/cite/cdb10/metadataAndVersioning/VerifyMaterialsXmlStructureTests.java
@@ -72,7 +72,7 @@ public class VerifyMaterialsXmlStructureTests extends MetadataTestFixture<Materi
         Files.copy(NAME_NOT_UNIQUE_FILE, metadataFolder.resolve("Materials.xml"), REPLACE_EXISTING);
         Files.createFile(schemaFolder.resolve(Paths.get("Base_Material_Table.xsd")));
 
-        String expectedMessage = "Materials.xml element Name should be unique. " +
+        String expectedMessage = "Materials.xml element \"<Name>\" should be unique. " +
                 "'BM_ASH-VOLCANIC' is not unique. expected [1] but found [2]";
 
         expectedException.expect(AssertionError.class);
@@ -98,8 +98,8 @@ public class VerifyMaterialsXmlStructureTests extends MetadataTestFixture<Materi
         Files.copy(MISSING_NAME_ELEMENT_FILE, metadataFolder.resolve("Materials.xml"), REPLACE_EXISTING);
         Files.createFile(schemaFolder.resolve(Paths.get("Base_Material_Table.xsd")));
 
-        String expectedMessage = "Materials.xml element Base_Material requires a " +
-                "child element Name. expected [0] but found [1]";
+        String expectedMessage = "Materials.xml element \"<Base_Material>\" requires a " +
+                "child element \"<Name>\". expected [0] but found [1]";
 
         expectedException.expect(AssertionError.class);
         expectedException.expectMessage(expectedMessage);
@@ -124,11 +124,11 @@ public class VerifyMaterialsXmlStructureTests extends MetadataTestFixture<Materi
         Files.copy(INVALID_NAME_VALUE_FILE, metadataFolder.resolve("Materials.xml"), REPLACE_EXISTING);
         Files.createFile(schemaFolder.resolve(Paths.get("Base_Material_Table.xsd")));
 
-        String expectedMessage = "Materials.xml element Name is always in format \"BM__*\", " +
+        String expectedMessage = "Materials.xml element \"<Name>\" is always in format \"BM__*\", " +
                 "has a maximum of 32 characters, and can only contain letters, digits, " +
                 "underscores, and hyphens. " +
                 "[ASH, BM_ASH-VOLCANIC*, BM_12345123451234512345123451234512345] " +
-                "do not conform expected [0] but found [3]";
+                "does not conform. expected [0] but found [3]";
 
         expectedException.expect(AssertionError.class);
         expectedException.expectMessage(expectedMessage);


### PR DESCRIPTION
Resolves #20.

Some tests validate against multiple tests in Annex A, particularly those that validate file names. Some tests validate against items mentioned in sections of Volume 1 and do not reference specific test requirements. For these cases I tried to find the tests and sections if possible.

One Metadata test was removed as it did not do anything; it would check to see if an optional file existed and if it didn't exist would return a message saying the file wasn't found and was optional.