### PR TITLE
Support custom schema for Geomatics/Vendor Attributes

### DIFF
--- a/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/GeomaticsAttributesXmlStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/GeomaticsAttributesXmlStructureTests.java
@@ -7,7 +7,6 @@ import org.testng.annotations.Test;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
-import java.nio.file.Files;
 
 /**
  * Created by martin on 2016-09-10.
@@ -26,7 +25,7 @@ public class GeomaticsAttributesXmlStructureTests extends Capability2Tests {
 	}
 	
 	private Boolean xmlFileExists() {
-		return Files.exists(this.geomaticsAttributes.getXmlFilePath());
+		return this.geomaticsAttributes.xmlFileExists();
 	}
 
     @Test(description = "OGC 15-113r5, Section 3.1.1")

--- a/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/GeomaticsAttributesXmlStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/GeomaticsAttributesXmlStructureTests.java
@@ -1,58 +1,30 @@
 package org.opengis.cite.cdb10.metadataAndVersioning;
 
-import org.opengis.cite.cdb10.util.metadataXml.GeomaticsAttributesXml;
-import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.Test;
-import org.xml.sax.SAXException;
 
-import java.io.IOException;
-
-/**
- * Created by martin on 2016-09-10.
- */
 public class GeomaticsAttributesXmlStructureTests extends Capability2Tests {
 	
-	private final static String NO_XML_SKIP = "Will not check for Geomatics Attributes Schema file as no Geomatics Attributes XML file exists.";
-	
-	private GeomaticsAttributesXml geomaticsAttributes;
+	private final static String SKIP_GEOMATICS_ATTRIBUTES = "The OGC CDB 1.0 standard is unclear about whether Vendor_Attributes.xsd and Geomatics_Attributes.xsd, or Vector_Attributes.xsd should be used. Therefore this test is skipped.";
 
 	/**
-	 * Initialize the GeomaticsAttributesXml validation class.
+	 * Verify that the schema file exists for a Geomatics Attributes XML file.
+	 * If no Geomatics Attributes XML file exists, then this test is skipped.
+	 * 
+	 * Due to ambiguities in OGC CDB Standard 1.0, this test is always skipped.
 	 */
-	private void loadXmlFile() {
-		this.geomaticsAttributes = new GeomaticsAttributesXml(path);
-	}
-	
-	private Boolean xmlFileExists() {
-		return this.geomaticsAttributes.xmlFileExists();
-	}
-
     @Test(description = "OGC 15-113r5, Section 3.1.1")
     public void verifyGeomaticsAttributesSchemaExists() {
-        this.loadXmlFile();
-        // If there is no "Geomatics_Attributes.xml", then skip
-        if (!this.xmlFileExists()) {
-        	throw new SkipException(NO_XML_SKIP);
-        }
-        
-		Assert.assertTrue(geomaticsAttributes.xsdFileExists(),
-				"Schema could not be loaded from XML 'schemaLocation'.");
+        throw new SkipException(SKIP_GEOMATICS_ATTRIBUTES);
     }
 
+    /** If the Geomatics Attributes XML and Schema files exist, then verify the
+     * XML against the schema.
+     * 
+	 * Due to ambiguities in OGC CDB Standard 1.0, this test is always skipped.
+     */
     @Test(description = "OGC 15-113r5, A.1.19, Test 77")
-    public void verifyGeomaticsAttributesAgainstSchema() throws IOException, SAXException {
-        this.loadXmlFile();
-        // If there is no "Geomatics_Attributes.xml", then skip
-        if (!this.xmlFileExists()) {
-        	throw new SkipException(NO_XML_SKIP);
-        }
-        
-        Assert.assertTrue(geomaticsAttributes.xsdFileExists(),
-				String.format("Metadata directory should contain %s file.", geomaticsAttributes.getXsdFileName()));
-        
-        String errors = geomaticsAttributes.schemaValidationErrors();
-        Assert.assertEquals(errors, "", geomaticsAttributes.getXmlFileName() + 
-        		" does not validate against its XML Schema file. Errors: " + errors);
+    public void verifyGeomaticsAttributesAgainstSchema() {
+        throw new SkipException(SKIP_GEOMATICS_ATTRIBUTES);
     }
 }

--- a/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/GeomaticsAttributesXmlStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/GeomaticsAttributesXmlStructureTests.java
@@ -29,7 +29,7 @@ public class GeomaticsAttributesXmlStructureTests extends Capability2Tests {
         if (!this.xmlFileExists()) { return; }
         
 		Assert.assertTrue(geomaticsAttributes.xsdFileExists(),
-				String.format("Metadata directory should contain %s file.", geomaticsAttributes.getXsdFileName()));
+				"Schema could not be loaded from XML 'schemaLocation'.");
     }
 
     @Test(description = "OGC 15-113r5, A.1.19, Test 77")

--- a/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/GeomaticsAttributesXmlStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/GeomaticsAttributesXmlStructureTests.java
@@ -48,8 +48,6 @@ public class GeomaticsAttributesXmlStructureTests extends Capability2Tests {
         	throw new SkipException(NO_XML_SKIP);
         }
         
-        Assert.assertTrue(geomaticsAttributes.xmlFileExists(),
-    			String.format("Metadata directory should contain %s file.", geomaticsAttributes.getXmlFileName()));
         Assert.assertTrue(geomaticsAttributes.xsdFileExists(),
 				String.format("Metadata directory should contain %s file.", geomaticsAttributes.getXsdFileName()));
         

--- a/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/GeomaticsAttributesXmlStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/GeomaticsAttributesXmlStructureTests.java
@@ -2,6 +2,7 @@ package org.opengis.cite.cdb10.metadataAndVersioning;
 
 import org.opengis.cite.cdb10.util.metadataXml.GeomaticsAttributesXml;
 import org.testng.Assert;
+import org.testng.SkipException;
 import org.testng.annotations.Test;
 import org.xml.sax.SAXException;
 
@@ -13,8 +14,13 @@ import java.nio.file.Files;
  */
 public class GeomaticsAttributesXmlStructureTests extends Capability2Tests {
 	
+	private final static String NO_XML_SKIP = "Will not check for Geomatics Attributes Schema file as no Geomatics Attributes XML file exists.";
+	
 	private GeomaticsAttributesXml geomaticsAttributes;
 
+	/**
+	 * Initialize the GeomaticsAttributesXml validation class.
+	 */
 	private void loadXmlFile() {
 		this.geomaticsAttributes = new GeomaticsAttributesXml(path);
 	}
@@ -24,18 +30,24 @@ public class GeomaticsAttributesXmlStructureTests extends Capability2Tests {
 	}
 
     @Test(description = "OGC 15-113r5, Section 3.1.1")
-    public void verifyGeomaticsAttributesXsdFileExists() {
+    public void verifyGeomaticsAttributesSchemaExists() {
         this.loadXmlFile();
-        if (!this.xmlFileExists()) { return; }
+        // If there is no "Geomatics_Attributes.xml", then skip
+        if (!this.xmlFileExists()) {
+        	throw new SkipException(NO_XML_SKIP);
+        }
         
 		Assert.assertTrue(geomaticsAttributes.xsdFileExists(),
 				"Schema could not be loaded from XML 'schemaLocation'.");
     }
 
     @Test(description = "OGC 15-113r5, A.1.19, Test 77")
-    public void verifyGeomaticsAttributesXmlAgainstSchema() throws IOException, SAXException {
+    public void verifyGeomaticsAttributesAgainstSchema() throws IOException, SAXException {
         this.loadXmlFile();
-        if (!this.xmlFileExists()) { return; }
+        // If there is no "Geomatics_Attributes.xml", then skip
+        if (!this.xmlFileExists()) {
+        	throw new SkipException(NO_XML_SKIP);
+        }
         
         Assert.assertTrue(geomaticsAttributes.xmlFileExists(),
     			String.format("Metadata directory should contain %s file.", geomaticsAttributes.getXmlFileName()));

--- a/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/VendorAttributesXmlStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/VendorAttributesXmlStructureTests.java
@@ -33,7 +33,7 @@ public class VendorAttributesXmlStructureTests extends Capability2Tests {
 	 * If no Vendor Attributes XML file exists, then this test is skipped.
 	 */
     @Test(description = "OGC 15-113r5, Section 3.1.1")
-    public void verifyVendorAttributesXsdFileExists() {
+    public void verifyVendorAttributesSchemaExists() {
         this.loadXmlFile();
         // If there is no "Vendor_Attributes.xml", then skip
         if (!this.xmlFileExists()) {

--- a/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/VendorAttributesXmlStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/VendorAttributesXmlStructureTests.java
@@ -1,68 +1,33 @@
 package org.opengis.cite.cdb10.metadataAndVersioning;
 
-import java.io.IOException;
-
-import org.opengis.cite.cdb10.util.metadataXml.VendorAttributesXml;
-import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.Test;
-import org.xml.sax.SAXException;
 
 /**
  * Created by martin on 2016-09-09.
  */
 public class VendorAttributesXmlStructureTests extends Capability2Tests {
 	
-	private final static String NO_XML_SKIP = "Will not check for Vendor Attributes Schema file as no Vendor Attributes XML file exists.";
-	
-	private VendorAttributesXml vendorAttributes;
-
-	/**
-	 * Initialize the VendorAttributesXml validation class.
-	 */
-	private void loadXmlFile() {
-		this.vendorAttributes = new VendorAttributesXml(path);
-	}
-	
-	private Boolean xmlFileExists() {
-		return this.vendorAttributes.xmlFileExists();
-	}
+	private final static String SKIP_VENDOR_ATTRIBUTES = "The OGC CDB 1.0 standard is unclear about whether Vendor_Attributes.xsd and Geomatics_Attributes.xsd, or Vector_Attributes.xsd should be used. Therefore this test is skipped.";
 
 	/**
 	 * Verify that the schema file exists for a Vendor Attributes XML file.
 	 * If no Vendor Attributes XML file exists, then this test is skipped.
+	 * 
+	 * Due to ambiguities in OGC CDB Standard 1.0, this test is always skipped.
 	 */
     @Test(description = "OGC 15-113r5, Section 3.1.1")
-    public void verifyVendorAttributesSchemaExists() {
-        this.loadXmlFile();
-        // If there is no "Vendor_Attributes.xml", then skip
-        if (!this.xmlFileExists()) {
-        	throw new SkipException(NO_XML_SKIP);
-        }
-        
-		Assert.assertTrue(vendorAttributes.xsdFileExists(),
-				"Schema could not be loaded from XML 'schemaLocation'.");
+    public void verifyVendorAttributesSchemaExists() {        
+        throw new SkipException(SKIP_VENDOR_ATTRIBUTES);
     }
 
     /** If the Vendor Attributes XML and Schema files exist, then verify the
      * XML against the schema.
      * 
-     * @throws IOException Error reading XML or Schema file
-     * @throws SAXException Error parsing XML or Schema file
+	 * Due to ambiguities in OGC CDB Standard 1.0, this test is always skipped.
      */
     @Test(description = "OGC 15-113r5, A.1.19, Test 76")
-    public void verifyVendorAttributesXmlAgainstSchema() throws IOException, SAXException {
-        this.loadXmlFile();
-        // If there is no "Vendor_Attributes.xml", then skip
-        if (!this.xmlFileExists()) {
-        	throw new SkipException(NO_XML_SKIP);
-        }
-        
-        Assert.assertTrue(vendorAttributes.xsdFileExists(),
-				String.format("Metadata directory should contain %s file.", vendorAttributes.getXsdFileName()));
-        
-        String errors = vendorAttributes.schemaValidationErrors();
-        Assert.assertEquals(errors, "", vendorAttributes.getXmlFileName() + 
-        		" does not validate against its XML Schema file. Errors: " + errors);
+    public void verifyVendorAttributesXmlAgainstSchema() {
+    	throw new SkipException(SKIP_VENDOR_ATTRIBUTES);
     }
 }

--- a/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/VendorAttributesXmlStructureTests.java
+++ b/src/main/java/org/opengis/cite/cdb10/metadataAndVersioning/VendorAttributesXmlStructureTests.java
@@ -1,10 +1,10 @@
 package org.opengis.cite.cdb10.metadataAndVersioning;
 
 import java.io.IOException;
-import java.nio.file.Files;
 
 import org.opengis.cite.cdb10.util.metadataXml.VendorAttributesXml;
 import org.testng.Assert;
+import org.testng.SkipException;
 import org.testng.annotations.Test;
 import org.xml.sax.SAXException;
 
@@ -13,14 +13,19 @@ import org.xml.sax.SAXException;
  */
 public class VendorAttributesXmlStructureTests extends Capability2Tests {
 	
+	private final static String NO_XML_SKIP = "Will not check for Vendor Attributes Schema file as no Vendor Attributes XML file exists.";
+	
 	private VendorAttributesXml vendorAttributes;
 
+	/**
+	 * Initialize the VendorAttributesXml validation class.
+	 */
 	private void loadXmlFile() {
 		this.vendorAttributes = new VendorAttributesXml(path);
 	}
 	
 	private Boolean xmlFileExists() {
-		return Files.exists(this.vendorAttributes.getXmlFilePath());
+		return this.vendorAttributes.xmlFileExists();
 	}
 
 	/**
@@ -30,10 +35,13 @@ public class VendorAttributesXmlStructureTests extends Capability2Tests {
     @Test(description = "OGC 15-113r5, Section 3.1.1")
     public void verifyVendorAttributesXsdFileExists() {
         this.loadXmlFile();
-        if (!this.xmlFileExists()) { return; }
+        // If there is no "Vendor_Attributes.xml", then skip
+        if (!this.xmlFileExists()) {
+        	throw new SkipException(NO_XML_SKIP);
+        }
         
 		Assert.assertTrue(vendorAttributes.xsdFileExists(),
-				String.format("Metadata directory should contain %s file.", vendorAttributes.getXsdFileName()));
+				"Schema could not be loaded from XML 'schemaLocation'.");
     }
 
     /** If the Vendor Attributes XML and Schema files exist, then verify the
@@ -45,10 +53,11 @@ public class VendorAttributesXmlStructureTests extends Capability2Tests {
     @Test(description = "OGC 15-113r5, A.1.19, Test 76")
     public void verifyVendorAttributesXmlAgainstSchema() throws IOException, SAXException {
         this.loadXmlFile();
-        if (!this.xmlFileExists()) { return; }
+        // If there is no "Vendor_Attributes.xml", then skip
+        if (!this.xmlFileExists()) {
+        	throw new SkipException(NO_XML_SKIP);
+        }
         
-        Assert.assertTrue(vendorAttributes.xmlFileExists(),
-    			String.format("Metadata directory should contain %s file.", vendorAttributes.getXmlFileName()));
         Assert.assertTrue(vendorAttributes.xsdFileExists(),
 				String.format("Metadata directory should contain %s file.", vendorAttributes.getXsdFileName()));
         

--- a/src/main/java/org/opengis/cite/cdb10/util/metadataXml/AttributesXml.java
+++ b/src/main/java/org/opengis/cite/cdb10/util/metadataXml/AttributesXml.java
@@ -1,0 +1,176 @@
+package org.opengis.cite.cdb10.util.metadataXml;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPathExpressionException;
+
+import org.opengis.cite.cdb10.util.SchemaValidatorErrorHandler;
+import org.opengis.cite.cdb10.util.URIUtils;
+import org.opengis.cite.cdb10.util.XMLUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/**
+ * Provides validation methods compatible with Geomatics Attributes and Vendor
+ * Attributes metadata files.
+ * See GeomaticsAttributesXml and VendorAttributesXml for more information.
+ */
+public class AttributesXml {
+	protected File xmlFile;
+	protected File xsdFile;
+	
+    public AttributesXml(String path, String filename, String schemaXPath) {
+        this.xmlFile = Paths.get(path, "Metadata", filename).toFile();
+        this.xsdFile = null;
+        
+        // Parse XML for schema location
+        String schemaLocation = this.loadSchemaLocation(schemaXPath);
+        
+        // Get local copy of schema, if necessary
+        if (schemaLocation.isEmpty()) {
+        	// Do nothing, leave xsdFile as null
+        } else if (schemaLocation.toLowerCase().startsWith("http")) {
+        	// Schema starts with HTTP, download it
+        	this.loadRemoteSchema(schemaLocation);
+        } else {
+        	// Try to load it locally
+        	this.xsdFile = Paths.get(path, "Metadata", schemaLocation).toFile();
+        }
+    }
+    
+    /**
+     * For this instance, download the schema from schemaLocation and set it
+     * as the schema file.
+     * @param schemaLocation HTTP/HTTPS URI pointing to schema
+     */
+    protected void loadRemoteSchema(String schemaLocation) {
+    	URI schemaURI = null;
+		try {
+			schemaURI = new URI(schemaLocation);
+		} catch (URISyntaxException e) {
+			// Invalid schema URI
+		}
+		
+    	try {
+			this.xsdFile = URIUtils.dereferenceURI(schemaURI);
+			
+			// If nothing is downloaded, then an empty directory is created
+			// and we need to catch that.
+			if (!this.xsdFile.isFile()) {
+				this.xsdFile = null;
+			}
+		} catch (IOException e) {
+			// Cannot retrieve schema
+		}
+    }
+    
+    /**
+     * Attempt to load the XML file and extract the schemaLocation as a String.
+     * "schemaLocation" may be a relative file path or a URL.
+     * If there are errors then an empty string is returned.
+     * @return String XML schema location
+     */
+    private String loadSchemaLocation(String schemaXPath) {
+    	DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder db = null;
+		try {
+			db = dbFactory.newDocumentBuilder();
+		} catch (ParserConfigurationException e1) {
+			return "";
+		}
+		
+        Document xmlDoc = null;
+		try {
+			xmlDoc = db.parse(this.xmlFile);
+		} catch (SAXException | IOException e1) {
+			return "";
+		}
+		
+		// We use an empty namespace mapping as we do not need one for
+		// schemaLocation.
+        Map<String, String> mappings = new HashMap<String, String>();
+        NodeList schemaInfo = null;
+        try {
+			schemaInfo = XMLUtils.evaluateXPath(xmlDoc, schemaXPath, mappings);
+		} catch (XPathExpressionException e) {
+			return "";
+		}
+        
+        // Check for only a single schemaLocation match
+        if (schemaInfo.getLength() != 1) {
+        	return "";
+        } else {
+        	return schemaInfo.item(0).getTextContent();
+        }
+    }
+    
+    public String getXmlFileName() {
+		if (this.xmlFile == null) {
+			return null;
+		} else {
+			return this.xmlFile.getName();
+		}
+	}
+	
+	public Path getXmlFilePath() {
+		if (this.xmlFile == null) {
+			return null;
+		} else {
+			return this.xmlFile.toPath();
+		}
+	}
+	
+	public String getXsdFileName() {
+		if (this.xsdFile == null) {
+			return null;
+		} else {
+			return this.xsdFile.getName();
+		}
+	}
+	
+	public Path getXsdFilePath() {
+		if (this.xsdFile == null) {
+			return null;
+		} else {
+			return this.xsdFile.toPath();
+		}
+	}
+	
+	public boolean xmlFileExists() {
+		if (this.xmlFile == null) {
+			return false;
+		} else {
+			return Files.exists(this.xmlFile.toPath());
+		}
+	}
+	
+	public boolean xsdFileExists() {
+		if (this.xsdFile == null) {
+			return false;
+		} else {
+			return Files.exists(this.xsdFile.toPath());
+		}
+	}
+	
+	public String schemaValidationErrors() throws SAXException, IOException {
+		SchemaValidatorErrorHandler errorHandler = XMLUtils.validateXmlFileIsValid(this.xmlFile, this.xsdFile);
+
+		if (!errorHandler.noErrors()) {
+			return errorHandler.getMessages();
+		} else {
+			return "";
+		}
+	}
+}

--- a/src/main/java/org/opengis/cite/cdb10/util/metadataXml/GeomaticsAttributesXml.java
+++ b/src/main/java/org/opengis/cite/cdb10/util/metadataXml/GeomaticsAttributesXml.java
@@ -73,6 +73,12 @@ public class GeomaticsAttributesXml {
 		
     	try {
 			this.xsdFile = URIUtils.dereferenceURI(schemaURI);
+			
+			// If nothing is downloaded, then an empty directory is created
+			// and we need to catch that.
+			if (!this.xsdFile.isFile()) {
+				this.xsdFile = null;
+			}
 		} catch (IOException e) {
 			// Cannot retrieve schema
 		}

--- a/src/main/java/org/opengis/cite/cdb10/util/metadataXml/GeomaticsAttributesXml.java
+++ b/src/main/java/org/opengis/cite/cdb10/util/metadataXml/GeomaticsAttributesXml.java
@@ -49,7 +49,7 @@ public class GeomaticsAttributesXml {
         // Get local copy of schema, if necessary
         if (schemaLocation.isEmpty()) {
         	// Do nothing, leave xsdFile as null
-        } else if (schemaLocation.matches("/^http/i")) {
+        } else if (schemaLocation.toLowerCase().startsWith("http")) {
         	// Schema starts with HTTP, download it
         	this.loadRemoteSchema(schemaLocation);
         } else {

--- a/src/main/java/org/opengis/cite/cdb10/util/metadataXml/GeomaticsAttributesXml.java
+++ b/src/main/java/org/opengis/cite/cdb10/util/metadataXml/GeomaticsAttributesXml.java
@@ -1,19 +1,178 @@
 package org.opengis.cite.cdb10.util.metadataXml;
 
-import org.testng.Assert;
+import org.opengis.cite.cdb10.util.SchemaValidatorErrorHandler;
+import org.opengis.cite.cdb10.util.URIUtils;
+import org.opengis.cite.cdb10.util.XMLUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPathExpressionException;
 
 /**
- * Created by martin on 2016-11-18.
+ * Provides validation methods for "Geomatics_Attributes.xml". Initialize with
+ * a path to a CDB Root and the appropriate XML metadata file will be detected.
+ * 
+ * This class has been separated from "MetadataXmlFile" to handle different
+ * logic for optional XML files, and for support for remote XSD files.
  */
-public class GeomaticsAttributesXml extends MetadataXmlFile {
+public class GeomaticsAttributesXml {
+	
+	private static final String GEOMATICS_ATTRIBUTES_XML = "Geomatics_Attributes.xml";
+	/**
+	 * This selects the user-defined schemaLocation so we can load it.
+	 */
+	private static final String SCHEMA_XPATH = "/Geomatics_Attributes/@schemaLocation";
+	protected File xmlFile;
+	protected File xsdFile;
+	
     public GeomaticsAttributesXml(String path) {
-        super(path, "Geomatics_Attributes.xml", "Geomatics_Attributes.xsd");
+        this.xmlFile = Paths.get(path, "Metadata", GEOMATICS_ATTRIBUTES_XML).toFile();
+        this.xsdFile = null;
+        
+        // Parse XML for schema location
+        String schemaLocation = this.loadSchemaLocation();
+        
+        // Get local copy of schema, if necessary
+        if (schemaLocation.isEmpty()) {
+        	// Do nothing, leave xsdFile as null
+        } else if (schemaLocation.matches("/^http/i")) {
+        	// Schema starts with HTTP, download it
+        	this.loadRemoteSchema(schemaLocation);
+        } else {
+        	// Try to load it locally
+        	this.xsdFile = Paths.get(path, "Metadata", schemaLocation).toFile();
+        }
     }
+    
+    /**
+     * For this instance, download the schema from schemaLocation and set it
+     * as the schema file.
+     * @param schemaLocation HTTP/HTTPS URI pointing to schema
+     */
+    protected void loadRemoteSchema(String schemaLocation) {
+    	URI schemaURI = null;
+		try {
+			schemaURI = new URI(schemaLocation);
+		} catch (URISyntaxException e) {
+			// Invalid schema URI
+		}
+		
+    	try {
+			this.xsdFile = URIUtils.dereferenceURI(schemaURI);
+		} catch (IOException e) {
+			// Cannot retrieve schema
+		}
+    }
+    
+    /**
+     * Attempt to load the XML file and extract the schemaLocation as a String.
+     * "schemaLocation" may be a relative file path or a URL.
+     * If there are errors then an empty string is returned.
+     * @return String XML schema location
+     */
+    private String loadSchemaLocation() {
+    	DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder db = null;
+		try {
+			db = dbFactory.newDocumentBuilder();
+		} catch (ParserConfigurationException e1) {
+			return "";
+		}
+		
+        Document xmlDoc = null;
+		try {
+			xmlDoc = db.parse(this.xmlFile);
+		} catch (SAXException | IOException e1) {
+			return "";
+		}
+		
+		// We use an empty namespace mapping as we do not need one for
+		// schemaLocation.
+        Map<String, String> mappings = new HashMap<String, String>();
+        NodeList schemaInfo = null;
+        try {
+			schemaInfo = XMLUtils.evaluateXPath(xmlDoc, SCHEMA_XPATH, mappings);
+		} catch (XPathExpressionException e) {
+			return "";
+		}
+        
+        // Check for only a single schemaLocation match
+        if (schemaInfo.getLength() != 1) {
+        	return "";
+        } else {
+        	return schemaInfo.item(0).getTextContent();
+        }
+    }
+    
+    public String getXmlFileName() {
+		if (this.xmlFile == null) {
+			return null;
+		} else {
+			return this.xmlFile.getName();
+		}
+	}
+	
+	public Path getXmlFilePath() {
+		if (this.xmlFile == null) {
+			return null;
+		} else {
+			return this.xmlFile.toPath();
+		}
+	}
+	
+	public String getXsdFileName() {
+		if (this.xsdFile == null) {
+			return null;
+		} else {
+			return this.xsdFile.getName();
+		}
+	}
+	
+	public Path getXsdFilePath() {
+		if (this.xsdFile == null) {
+			return null;
+		} else {
+			return this.xsdFile.toPath();
+		}
+	}
+	
+	public boolean xmlFileExists() {
+		if (this.xmlFile == null) {
+			return false;
+		} else {
+			return Files.exists(this.xmlFile.toPath());
+		}
+	}
+	
+	public boolean xsdFileExists() {
+		if (this.xsdFile == null) {
+			return false;
+		} else {
+			return Files.exists(this.xsdFile.toPath());
+		}
+	}
+	
+	public String schemaValidationErrors() throws SAXException, IOException {
+		SchemaValidatorErrorHandler errorHandler = XMLUtils.validateXmlFileIsValid(this.xmlFile, this.xsdFile);
 
-    public void verifyGeomaticsAttributesXsdFileExists() {
-        Assert.assertTrue(Files.exists(xsdFile.toPath()),
-                "If Geomatics_Attributes.xml exists there should be a Geomatics_Attributes.xsd in the Schema folder");
-    }
+		if (!errorHandler.noErrors()) {
+			return errorHandler.getMessages();
+		} else {
+			return "";
+		}
+	}
 }

--- a/src/main/java/org/opengis/cite/cdb10/util/metadataXml/GeomaticsAttributesXml.java
+++ b/src/main/java/org/opengis/cite/cdb10/util/metadataXml/GeomaticsAttributesXml.java
@@ -1,27 +1,5 @@
 package org.opengis.cite.cdb10.util.metadataXml;
 
-import org.opengis.cite.cdb10.util.SchemaValidatorErrorHandler;
-import org.opengis.cite.cdb10.util.URIUtils;
-import org.opengis.cite.cdb10.util.XMLUtils;
-import org.w3c.dom.Document;
-import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.xpath.XPathExpressionException;
-
 /**
  * Provides validation methods for "Geomatics_Attributes.xml". Initialize with
  * a path to a CDB Root and the appropriate XML metadata file will be detected.
@@ -29,156 +7,15 @@ import javax.xml.xpath.XPathExpressionException;
  * This class has been separated from "MetadataXmlFile" to handle different
  * logic for optional XML files, and for support for remote XSD files.
  */
-public class GeomaticsAttributesXml {
+public class GeomaticsAttributesXml extends AttributesXml {
 	
-	private static final String GEOMATICS_ATTRIBUTES_XML = "Geomatics_Attributes.xml";
+	private static final String METADATA_FILENAME = "Geomatics_Attributes.xml";
 	/**
 	 * This selects the user-defined schemaLocation so we can load it.
 	 */
 	private static final String SCHEMA_XPATH = "/Geomatics_Attributes/@schemaLocation";
-	protected File xmlFile;
-	protected File xsdFile;
 	
     public GeomaticsAttributesXml(String path) {
-        this.xmlFile = Paths.get(path, "Metadata", GEOMATICS_ATTRIBUTES_XML).toFile();
-        this.xsdFile = null;
-        
-        // Parse XML for schema location
-        String schemaLocation = this.loadSchemaLocation();
-        
-        // Get local copy of schema, if necessary
-        if (schemaLocation.isEmpty()) {
-        	// Do nothing, leave xsdFile as null
-        } else if (schemaLocation.toLowerCase().startsWith("http")) {
-        	// Schema starts with HTTP, download it
-        	this.loadRemoteSchema(schemaLocation);
-        } else {
-        	// Try to load it locally
-        	this.xsdFile = Paths.get(path, "Metadata", schemaLocation).toFile();
-        }
+    	super(path, METADATA_FILENAME, SCHEMA_XPATH);
     }
-    
-    /**
-     * For this instance, download the schema from schemaLocation and set it
-     * as the schema file.
-     * @param schemaLocation HTTP/HTTPS URI pointing to schema
-     */
-    protected void loadRemoteSchema(String schemaLocation) {
-    	URI schemaURI = null;
-		try {
-			schemaURI = new URI(schemaLocation);
-		} catch (URISyntaxException e) {
-			// Invalid schema URI
-		}
-		
-    	try {
-			this.xsdFile = URIUtils.dereferenceURI(schemaURI);
-			
-			// If nothing is downloaded, then an empty directory is created
-			// and we need to catch that.
-			if (!this.xsdFile.isFile()) {
-				this.xsdFile = null;
-			}
-		} catch (IOException e) {
-			// Cannot retrieve schema
-		}
-    }
-    
-    /**
-     * Attempt to load the XML file and extract the schemaLocation as a String.
-     * "schemaLocation" may be a relative file path or a URL.
-     * If there are errors then an empty string is returned.
-     * @return String XML schema location
-     */
-    private String loadSchemaLocation() {
-    	DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-        DocumentBuilder db = null;
-		try {
-			db = dbFactory.newDocumentBuilder();
-		} catch (ParserConfigurationException e1) {
-			return "";
-		}
-		
-        Document xmlDoc = null;
-		try {
-			xmlDoc = db.parse(this.xmlFile);
-		} catch (SAXException | IOException e1) {
-			return "";
-		}
-		
-		// We use an empty namespace mapping as we do not need one for
-		// schemaLocation.
-        Map<String, String> mappings = new HashMap<String, String>();
-        NodeList schemaInfo = null;
-        try {
-			schemaInfo = XMLUtils.evaluateXPath(xmlDoc, SCHEMA_XPATH, mappings);
-		} catch (XPathExpressionException e) {
-			return "";
-		}
-        
-        // Check for only a single schemaLocation match
-        if (schemaInfo.getLength() != 1) {
-        	return "";
-        } else {
-        	return schemaInfo.item(0).getTextContent();
-        }
-    }
-    
-    public String getXmlFileName() {
-		if (this.xmlFile == null) {
-			return null;
-		} else {
-			return this.xmlFile.getName();
-		}
-	}
-	
-	public Path getXmlFilePath() {
-		if (this.xmlFile == null) {
-			return null;
-		} else {
-			return this.xmlFile.toPath();
-		}
-	}
-	
-	public String getXsdFileName() {
-		if (this.xsdFile == null) {
-			return null;
-		} else {
-			return this.xsdFile.getName();
-		}
-	}
-	
-	public Path getXsdFilePath() {
-		if (this.xsdFile == null) {
-			return null;
-		} else {
-			return this.xsdFile.toPath();
-		}
-	}
-	
-	public boolean xmlFileExists() {
-		if (this.xmlFile == null) {
-			return false;
-		} else {
-			return Files.exists(this.xmlFile.toPath());
-		}
-	}
-	
-	public boolean xsdFileExists() {
-		if (this.xsdFile == null) {
-			return false;
-		} else {
-			return Files.exists(this.xsdFile.toPath());
-		}
-	}
-	
-	public String schemaValidationErrors() throws SAXException, IOException {
-		SchemaValidatorErrorHandler errorHandler = XMLUtils.validateXmlFileIsValid(this.xmlFile, this.xsdFile);
-
-		if (!errorHandler.noErrors()) {
-			return errorHandler.getMessages();
-		} else {
-			return "";
-		}
-	}
 }

--- a/src/main/java/org/opengis/cite/cdb10/util/metadataXml/VendorAttributesXml.java
+++ b/src/main/java/org/opengis/cite/cdb10/util/metadataXml/VendorAttributesXml.java
@@ -1,10 +1,21 @@
 package org.opengis.cite.cdb10.util.metadataXml;
 
 /**
- * Created by martin on 2016-11-10.
+ * Provides validation methods for "Vendor_Attributes.xml". Initialize with
+ * a path to a CDB Root and the appropriate XML metadata file will be detected.
+ * 
+ * This class has been separated from "MetadataXmlFile" to handle different
+ * logic for optional XML files, and for support for remote XSD files.
  */
-public class VendorAttributesXml extends MetadataXmlFile {
+public class VendorAttributesXml extends AttributesXml {
+	
+	private static final String METADATA_FILENAME = "Vendor_Attributes.xml";
+	/**
+	 * This selects the user-defined schemaLocation so we can load it.
+	 */
+	private static final String SCHEMA_XPATH = "/Vendor_Attributes/@schemaLocation";
+	
     public VendorAttributesXml(String path) {
-        super(path, "Vendor_Attributes.xml", "Vendor_Attributes.xsd");
+        super(path, METADATA_FILENAME, SCHEMA_XPATH);
     }
 }

--- a/src/test/java/org/opengis/cite/cdb10/fixtures/invalid/Geomatics_AttributesInvalid.xml
+++ b/src/test/java/org/opengis/cite/cdb10/fixtures/invalid/Geomatics_AttributesInvalid.xml
@@ -2,7 +2,7 @@
 <Geomatics_Attributes
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://www.CDB-Spec.org/Schema/Version/3.2"
-  xsi:schemaLocation="http://www.CDB-Spec.org/Schema/Version/3.2 Schema/Geomatics_Attributes.xsd">
+  xsi:schemaLocation="schema/Geomatics_Attributes.xsd">
 
   <Example_Element_1></Example_Element_1>
 

--- a/src/test/java/org/opengis/cite/cdb10/fixtures/invalid/Geomatics_AttributesInvalid.xml
+++ b/src/test/java/org/opengis/cite/cdb10/fixtures/invalid/Geomatics_AttributesInvalid.xml
@@ -2,7 +2,7 @@
 <Geomatics_Attributes
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://www.CDB-Spec.org/Schema/Version/3.2"
-  xsi:schemaLocation="schema/Geomatics_Attributes.xsd">
+  xsi:schemaLocation="Schema/Geomatics_Attributes.xsd">
 
   <Example_Element_1></Example_Element_1>
 

--- a/src/test/java/org/opengis/cite/cdb10/fixtures/invalid/Geomatics_Attributes_remote.xml
+++ b/src/test/java/org/opengis/cite/cdb10/fixtures/invalid/Geomatics_Attributes_remote.xml
@@ -2,7 +2,7 @@
 <Geomatics_Attributes
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://www.CDB-Spec.org/Schema/Version/3.2"
-  xsi:schemaLocation="schema/Geomatics_Attributes.xsd">
+  xsi:schemaLocation="http://www.example.org/Geomatics_Attributes.xsd">
 
   <Example_Element_1></Example_Element_1>
   <Example_Element_2></Example_Element_2>

--- a/src/test/java/org/opengis/cite/cdb10/fixtures/invalid/Vendor_AttributesRemoteMissing.xml
+++ b/src/test/java/org/opengis/cite/cdb10/fixtures/invalid/Vendor_AttributesRemoteMissing.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Vendor_Attributes
+<Geomatics_Attributes
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://www.CDB-Spec.org/Schema/Version/3.2"
-  xsi:schemaLocation="Schema/Vendor_Attributes.xsd">
+  xsi:schemaLocation="http://www.example.org/Vendor_Attributes.xsd">
 
   <Example_Element_1></Example_Element_1>
+  <Example_Element_2></Example_Element_2>
 
-</Vendor_Attributes>
+</Geomatics_Attributes>

--- a/src/test/java/org/opengis/cite/cdb10/fixtures/valid/Geomatics_Attributes.xml
+++ b/src/test/java/org/opengis/cite/cdb10/fixtures/valid/Geomatics_Attributes.xml
@@ -2,7 +2,7 @@
 <Geomatics_Attributes
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://www.CDB-Spec.org/Schema/Version/3.2"
-  xsi:schemaLocation="schema/Geomatics_Attributes.xsd">
+  xsi:schemaLocation="Schema/Geomatics_Attributes.xsd">
 
   <Example_Element_1></Example_Element_1>
   <Example_Element_2></Example_Element_2>

--- a/src/test/java/org/opengis/cite/cdb10/fixtures/valid/Geomatics_Attributes_remote.xml
+++ b/src/test/java/org/opengis/cite/cdb10/fixtures/valid/Geomatics_Attributes_remote.xml
@@ -2,7 +2,7 @@
 <Geomatics_Attributes
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://www.CDB-Spec.org/Schema/Version/3.2"
-  xsi:schemaLocation="schema/Geomatics_Attributes.xsd">
+  xsi:schemaLocation="http://www.CDB-Spec.org/Schema/Version/3.2 Schema/Geomatics_Attributes.xsd">
 
   <Example_Element_1></Example_Element_1>
   <Example_Element_2></Example_Element_2>

--- a/src/test/java/org/opengis/cite/cdb10/fixtures/valid/Vendor_Attributes.xml
+++ b/src/test/java/org/opengis/cite/cdb10/fixtures/valid/Vendor_Attributes.xml
@@ -2,7 +2,7 @@
 <Vendor_Attributes
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://www.CDB-Spec.org/Schema/Version/3.2"
-  xsi:schemaLocation="http://www.CDB-Spec.org/Schema/Version/3.2 Schema/Vendor_Attributes.xsd">
+  xsi:schemaLocation="Schema/Vendor_Attributes.xsd">
 
   <Example_Element_1></Example_Element_1>
   <Example_Element_2></Example_Element_2>

--- a/src/test/java/org/opengis/cite/cdb10/fixtures/valid/Vendor_Attributes_remote.xml
+++ b/src/test/java/org/opengis/cite/cdb10/fixtures/valid/Vendor_Attributes_remote.xml
@@ -2,8 +2,9 @@
 <Vendor_Attributes
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://www.CDB-Spec.org/Schema/Version/3.2"
-  xsi:schemaLocation="Schema/Vendor_Attributes.xsd">
+  xsi:schemaLocation="http://www.CDB-Spec.org/Schema/Version/3.2 Schema/Vendor_Attributes.xsd">
 
   <Example_Element_1></Example_Element_1>
+  <Example_Element_2></Example_Element_2>
 
 </Vendor_Attributes>

--- a/src/test/java/org/opengis/cite/cdb10/metadataAndVersioning/VerifyGeomaticsAttributesXmlStructureTests.java
+++ b/src/test/java/org/opengis/cite/cdb10/metadataAndVersioning/VerifyGeomaticsAttributesXmlStructureTests.java
@@ -21,7 +21,6 @@ public class VerifyGeomaticsAttributesXmlStructureTests extends MetadataTestFixt
     
 	private final static Path XSD_FILE = SOURCE_DIRECTORY.resolve(Paths.get("schema", GEOMATICS_ATTRIBUTES_XSD));
     private final static Path XML_LOCAL_XSD = SOURCE_DIRECTORY.resolve(Paths.get("valid", GEOMATICS_ATTRIBUTES_XML));
-    private final static Path XML_REMOTE_XSD = SOURCE_DIRECTORY.resolve(Paths.get("valid", "Geomatics_Attributes_remote.xml"));
     private final static Path XML_REMOTE_XSD_MISSING = SOURCE_DIRECTORY.resolve(Paths.get("invalid", "Geomatics_Attributes_remote.xml"));
     private final static Path XML_INVALID = SOURCE_DIRECTORY.resolve(Paths.get("invalid", "Geomatics_AttributesInvalid.xml"));
 
@@ -30,7 +29,7 @@ public class VerifyGeomaticsAttributesXmlStructureTests extends MetadataTestFixt
     }
     
     @Test
-    public void verifyGeomaticsAttributesXsdFileExists_XmlFileDoesNotExist() {
+    public void verifyGeomaticsAttributesSchemaExists_XmlFileDoesNotExist() {
     	// setup: No Geomatics_Attributes.xml
     	expectedException.expect(SkipException.class);
         expectedException.expectMessage("Will not check for Geomatics Attributes Schema file as no Geomatics Attributes XML file exists.");
@@ -40,7 +39,7 @@ public class VerifyGeomaticsAttributesXmlStructureTests extends MetadataTestFixt
     }
 
     @Test
-    public void verifyGeomaticsAttributesXsdFileExists_XsdDoesNotExist() throws IOException {
+    public void verifyGeomaticsAttributesSchemaExists_XsdDoesNotExist() throws IOException {
         // setup
         Files.copy(XML_LOCAL_XSD, metadataFolder.resolve(GEOMATICS_ATTRIBUTES_XML), REPLACE_EXISTING);
         expectedException.expect(AssertionError.class);
@@ -51,7 +50,7 @@ public class VerifyGeomaticsAttributesXmlStructureTests extends MetadataTestFixt
     }
     
     @Test
-    public void verifyGeomaticsAttributesXsdFileExists_RemoteXsdDoesNotExist() throws IOException {
+    public void verifyGeomaticsAttributesSchemaExists_RemoteXsdDoesNotExist() throws IOException {
         // setup
         Files.copy(XML_REMOTE_XSD_MISSING, metadataFolder.resolve(GEOMATICS_ATTRIBUTES_XML), REPLACE_EXISTING);
         expectedException.expect(AssertionError.class);
@@ -62,7 +61,7 @@ public class VerifyGeomaticsAttributesXmlStructureTests extends MetadataTestFixt
     }
 
     @Test
-    public void verifyGeomaticsAttributesXsdFileExists_XsdDoesExist() throws IOException {
+    public void verifyGeomaticsAttributesSchemaExists_XsdDoesExist() throws IOException {
         // setup
         Files.copy(XML_LOCAL_XSD, metadataFolder.resolve(GEOMATICS_ATTRIBUTES_XML), REPLACE_EXISTING);
         Files.copy(XSD_FILE, schemaFolder.resolve(GEOMATICS_ATTRIBUTES_XSD), REPLACE_EXISTING);

--- a/src/test/java/org/opengis/cite/cdb10/metadataAndVersioning/VerifyGeomaticsAttributesXmlStructureTests.java
+++ b/src/test/java/org/opengis/cite/cdb10/metadataAndVersioning/VerifyGeomaticsAttributesXmlStructureTests.java
@@ -1,6 +1,7 @@
 package org.opengis.cite.cdb10.metadataAndVersioning;
 
 import org.junit.Test;
+import org.testng.SkipException;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
@@ -31,8 +32,11 @@ public class VerifyGeomaticsAttributesXmlStructureTests extends MetadataTestFixt
     @Test
     public void verifyGeomaticsAttributesXsdFileExists_XmlFileDoesNotExist() {
     	// setup: No Geomatics_Attributes.xml
+    	expectedException.expect(SkipException.class);
+        expectedException.expectMessage("Will not check for Geomatics Attributes Schema file as no Geomatics Attributes XML file exists.");
+        
     	// execute
-    	testSuite.verifyGeomaticsAttributesXsdFileExists();
+    	testSuite.verifyGeomaticsAttributesSchemaExists();
     }
 
     @Test
@@ -43,7 +47,7 @@ public class VerifyGeomaticsAttributesXmlStructureTests extends MetadataTestFixt
         expectedException.expectMessage("Schema could not be loaded from XML 'schemaLocation'.");
 
         // execute
-        testSuite.verifyGeomaticsAttributesXsdFileExists();
+        testSuite.verifyGeomaticsAttributesSchemaExists();
     }
     
     @Test
@@ -54,7 +58,7 @@ public class VerifyGeomaticsAttributesXmlStructureTests extends MetadataTestFixt
         expectedException.expectMessage("Schema could not be loaded from XML 'schemaLocation'.");
 
         // execute
-        testSuite.verifyGeomaticsAttributesXsdFileExists();
+        testSuite.verifyGeomaticsAttributesSchemaExists();
     }
 
     @Test
@@ -64,7 +68,7 @@ public class VerifyGeomaticsAttributesXmlStructureTests extends MetadataTestFixt
         Files.copy(XSD_FILE, schemaFolder.resolve(GEOMATICS_ATTRIBUTES_XSD), REPLACE_EXISTING);
 
         // execute
-        testSuite.verifyGeomaticsAttributesXsdFileExists();
+        testSuite.verifyGeomaticsAttributesSchemaExists();
     }
 
     @Test
@@ -74,7 +78,7 @@ public class VerifyGeomaticsAttributesXmlStructureTests extends MetadataTestFixt
         Files.copy(XSD_FILE, schemaFolder.resolve(GEOMATICS_ATTRIBUTES_XSD), REPLACE_EXISTING);
 
         // execute
-        testSuite.verifyGeomaticsAttributesXmlAgainstSchema();
+        testSuite.verifyGeomaticsAttributesAgainstSchema();
     }
 
     @Test
@@ -92,6 +96,6 @@ public class VerifyGeomaticsAttributesXmlStructureTests extends MetadataTestFixt
         expectedException.expectMessage(expectedMessage);
 
         // execute
-        testSuite.verifyGeomaticsAttributesXmlAgainstSchema();
+        testSuite.verifyGeomaticsAttributesAgainstSchema();
     }
 }

--- a/src/test/java/org/opengis/cite/cdb10/metadataAndVersioning/VerifyGeomaticsAttributesXmlStructureTests.java
+++ b/src/test/java/org/opengis/cite/cdb10/metadataAndVersioning/VerifyGeomaticsAttributesXmlStructureTests.java
@@ -2,99 +2,20 @@ package org.opengis.cite.cdb10.metadataAndVersioning;
 
 import org.junit.Test;
 import org.testng.SkipException;
-import org.xml.sax.SAXException;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
-
-/**
- * Created by martin on 2016-09-10.
- */
 public class VerifyGeomaticsAttributesXmlStructureTests extends MetadataTestFixture<GeomaticsAttributesXmlStructureTests> {
-
-    private static final String GEOMATICS_ATTRIBUTES_XSD = "Geomatics_Attributes.xsd";
-	private static final String GEOMATICS_ATTRIBUTES_XML = "Geomatics_Attributes.xml";
-    
-	private final static Path XSD_FILE = SOURCE_DIRECTORY.resolve(Paths.get("schema", GEOMATICS_ATTRIBUTES_XSD));
-    private final static Path XML_LOCAL_XSD = SOURCE_DIRECTORY.resolve(Paths.get("valid", GEOMATICS_ATTRIBUTES_XML));
-    private final static Path XML_REMOTE_XSD_MISSING = SOURCE_DIRECTORY.resolve(Paths.get("invalid", "Geomatics_Attributes_remote.xml"));
-    private final static Path XML_INVALID = SOURCE_DIRECTORY.resolve(Paths.get("invalid", "Geomatics_AttributesInvalid.xml"));
-
+	
     public VerifyGeomaticsAttributesXmlStructureTests() {
         testSuite = new GeomaticsAttributesXmlStructureTests();
     }
     
     @Test
-    public void verifyGeomaticsAttributesSchemaExists_XmlFileDoesNotExist() {
+    public void verifyGeomaticsAttributesSchemaExists_Skips() {
     	// setup: No Geomatics_Attributes.xml
     	expectedException.expect(SkipException.class);
-        expectedException.expectMessage("Will not check for Geomatics Attributes Schema file as no Geomatics Attributes XML file exists.");
+        expectedException.expectMessage("The OGC CDB 1.0 standard is unclear about whether Vendor_Attributes.xsd and Geomatics_Attributes.xsd, or Vector_Attributes.xsd should be used. Therefore this test is skipped.");
         
     	// execute
     	testSuite.verifyGeomaticsAttributesSchemaExists();
-    }
-
-    @Test
-    public void verifyGeomaticsAttributesSchemaExists_XsdDoesNotExist() throws IOException {
-        // setup
-        Files.copy(XML_LOCAL_XSD, metadataFolder.resolve(GEOMATICS_ATTRIBUTES_XML), REPLACE_EXISTING);
-        expectedException.expect(AssertionError.class);
-        expectedException.expectMessage("Schema could not be loaded from XML 'schemaLocation'.");
-
-        // execute
-        testSuite.verifyGeomaticsAttributesSchemaExists();
-    }
-    
-    @Test
-    public void verifyGeomaticsAttributesSchemaExists_RemoteXsdDoesNotExist() throws IOException {
-        // setup
-        Files.copy(XML_REMOTE_XSD_MISSING, metadataFolder.resolve(GEOMATICS_ATTRIBUTES_XML), REPLACE_EXISTING);
-        expectedException.expect(AssertionError.class);
-        expectedException.expectMessage("Schema could not be loaded from XML 'schemaLocation'.");
-
-        // execute
-        testSuite.verifyGeomaticsAttributesSchemaExists();
-    }
-
-    @Test
-    public void verifyGeomaticsAttributesSchemaExists_XsdDoesExist() throws IOException {
-        // setup
-        Files.copy(XML_LOCAL_XSD, metadataFolder.resolve(GEOMATICS_ATTRIBUTES_XML), REPLACE_EXISTING);
-        Files.copy(XSD_FILE, schemaFolder.resolve(GEOMATICS_ATTRIBUTES_XSD), REPLACE_EXISTING);
-
-        // execute
-        testSuite.verifyGeomaticsAttributesSchemaExists();
-    }
-
-    @Test
-    public void verifyGeomaticsAttributesXmlAgainstSchema_XmlIsValid() throws IOException, SAXException {
-        // setup
-        Files.copy(XML_LOCAL_XSD, metadataFolder.resolve(GEOMATICS_ATTRIBUTES_XML), REPLACE_EXISTING);
-        Files.copy(XSD_FILE, schemaFolder.resolve(GEOMATICS_ATTRIBUTES_XSD), REPLACE_EXISTING);
-
-        // execute
-        testSuite.verifyGeomaticsAttributesAgainstSchema();
-    }
-
-    @Test
-    public void verifyGeomaticsAttributesXmlAgainstSchema_XmlIsNotValid() throws IOException, SAXException {
-        // setup
-        Files.copy(XML_INVALID, metadataFolder.resolve(GEOMATICS_ATTRIBUTES_XML), REPLACE_EXISTING);
-        Files.copy(XSD_FILE, schemaFolder.resolve(GEOMATICS_ATTRIBUTES_XSD), REPLACE_EXISTING);
-
-        String expectedMessage = "Geomatics_Attributes.xml does not validate against its XML Schema file. " +
-                "Errors: cvc-complex-type.2.4.b: The content of element 'Geomatics_Attributes' is not complete. " +
-                "One of '{\"http://www.CDB-Spec.org/Schema/Version/3.2\":Example_Element_2}' is expected.";
-
-
-        expectedException.expect(AssertionError.class);
-        expectedException.expectMessage(expectedMessage);
-
-        // execute
-        testSuite.verifyGeomaticsAttributesAgainstSchema();
     }
 }

--- a/src/test/java/org/opengis/cite/cdb10/metadataAndVersioning/VerifyGeomaticsAttributesXmlStructureTests.java
+++ b/src/test/java/org/opengis/cite/cdb10/metadataAndVersioning/VerifyGeomaticsAttributesXmlStructureTests.java
@@ -40,7 +40,7 @@ public class VerifyGeomaticsAttributesXmlStructureTests extends MetadataTestFixt
     }
 
     @Test
-    public void verifyGeomaticsAttributesXsdFileExists_DoesNotExist() throws IOException {
+    public void verifyGeomaticsAttributesXsdFileExists_XsdDoesNotExist() throws IOException {
         // setup
         Files.copy(XML_LOCAL_XSD, metadataFolder.resolve(GEOMATICS_ATTRIBUTES_XML), REPLACE_EXISTING);
         expectedException.expect(AssertionError.class);
@@ -62,7 +62,7 @@ public class VerifyGeomaticsAttributesXmlStructureTests extends MetadataTestFixt
     }
 
     @Test
-    public void verifyGeomaticsAttributesXsdFileExists_DoesExist() throws IOException {
+    public void verifyGeomaticsAttributesXsdFileExists_XsdDoesExist() throws IOException {
         // setup
         Files.copy(XML_LOCAL_XSD, metadataFolder.resolve(GEOMATICS_ATTRIBUTES_XML), REPLACE_EXISTING);
         Files.copy(XSD_FILE, schemaFolder.resolve(GEOMATICS_ATTRIBUTES_XSD), REPLACE_EXISTING);

--- a/src/test/java/org/opengis/cite/cdb10/metadataAndVersioning/VerifyGeomaticsAttributesXmlStructureTests.java
+++ b/src/test/java/org/opengis/cite/cdb10/metadataAndVersioning/VerifyGeomaticsAttributesXmlStructureTests.java
@@ -15,22 +15,43 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
  */
 public class VerifyGeomaticsAttributesXmlStructureTests extends MetadataTestFixture<GeomaticsAttributesXmlStructureTests> {
 
-    private final static Path XSD_FILE = SOURCE_DIRECTORY.resolve(Paths.get("schema", "Geomatics_Attributes.xsd"));
-
-    private final static Path VALID_FILE = SOURCE_DIRECTORY.resolve(Paths.get("valid", "Geomatics_Attributes.xml"));
-
-    private final static Path INVALID_FILE = SOURCE_DIRECTORY.resolve(Paths.get("invalid", "Geomatics_AttributesInvalid.xml"));
+    private static final String GEOMATICS_ATTRIBUTES_XSD = "Geomatics_Attributes.xsd";
+	private static final String GEOMATICS_ATTRIBUTES_XML = "Geomatics_Attributes.xml";
+    
+	private final static Path XSD_FILE = SOURCE_DIRECTORY.resolve(Paths.get("schema", GEOMATICS_ATTRIBUTES_XSD));
+    private final static Path XML_LOCAL_XSD = SOURCE_DIRECTORY.resolve(Paths.get("valid", GEOMATICS_ATTRIBUTES_XML));
+    private final static Path XML_REMOTE_XSD = SOURCE_DIRECTORY.resolve(Paths.get("valid", "Geomatics_Attributes_remote.xml"));
+    private final static Path XML_REMOTE_XSD_MISSING = SOURCE_DIRECTORY.resolve(Paths.get("invalid", "Geomatics_Attributes_remote.xml"));
+    private final static Path XML_INVALID = SOURCE_DIRECTORY.resolve(Paths.get("invalid", "Geomatics_AttributesInvalid.xml"));
 
     public VerifyGeomaticsAttributesXmlStructureTests() {
         testSuite = new GeomaticsAttributesXmlStructureTests();
     }
+    
+    @Test
+    public void verifyGeomaticsAttributesXsdFileExists_XmlFileDoesNotExist() {
+    	// setup: No Geomatics_Attributes.xml
+    	// execute
+    	testSuite.verifyGeomaticsAttributesXsdFileExists();
+    }
 
     @Test
-    public void verifyVendorAttributesXsdFileExists_DoesNotExist() throws IOException {
+    public void verifyGeomaticsAttributesXsdFileExists_DoesNotExist() throws IOException {
         // setup
-        Files.createFile(metadataFolder.resolve(Paths.get("Geomatics_Attributes.xml")));
+        Files.copy(XML_LOCAL_XSD, metadataFolder.resolve(GEOMATICS_ATTRIBUTES_XML), REPLACE_EXISTING);
         expectedException.expect(AssertionError.class);
-        expectedException.expectMessage("Metadata directory should contain Geomatics_Attributes.xsd file.");
+        expectedException.expectMessage("Schema could not be loaded from XML 'schemaLocation'.");
+
+        // execute
+        testSuite.verifyGeomaticsAttributesXsdFileExists();
+    }
+    
+    @Test
+    public void verifyGeomaticsAttributesXsdFileExists_RemoteXsdDoesNotExist() throws IOException {
+        // setup
+        Files.copy(XML_REMOTE_XSD_MISSING, metadataFolder.resolve(GEOMATICS_ATTRIBUTES_XML), REPLACE_EXISTING);
+        expectedException.expect(AssertionError.class);
+        expectedException.expectMessage("Schema could not be loaded from XML 'schemaLocation'.");
 
         // execute
         testSuite.verifyGeomaticsAttributesXsdFileExists();
@@ -39,8 +60,8 @@ public class VerifyGeomaticsAttributesXmlStructureTests extends MetadataTestFixt
     @Test
     public void verifyGeomaticsAttributesXsdFileExists_DoesExist() throws IOException {
         // setup
-        Files.createFile(metadataFolder.resolve(Paths.get("Geomatics_Attributes.xml")));
-        Files.createFile(schemaFolder.resolve(Paths.get("Geomatics_Attributes.xsd")));
+        Files.copy(XML_LOCAL_XSD, metadataFolder.resolve(GEOMATICS_ATTRIBUTES_XML), REPLACE_EXISTING);
+        Files.copy(XSD_FILE, schemaFolder.resolve(GEOMATICS_ATTRIBUTES_XSD), REPLACE_EXISTING);
 
         // execute
         testSuite.verifyGeomaticsAttributesXsdFileExists();
@@ -49,8 +70,8 @@ public class VerifyGeomaticsAttributesXmlStructureTests extends MetadataTestFixt
     @Test
     public void verifyGeomaticsAttributesXmlAgainstSchema_XmlIsValid() throws IOException, SAXException {
         // setup
-        Files.copy(VALID_FILE, metadataFolder.resolve("Geomatics_Attributes.xml"), REPLACE_EXISTING);
-        Files.copy(XSD_FILE, schemaFolder.resolve("Geomatics_Attributes.xsd"), REPLACE_EXISTING);
+        Files.copy(XML_LOCAL_XSD, metadataFolder.resolve(GEOMATICS_ATTRIBUTES_XML), REPLACE_EXISTING);
+        Files.copy(XSD_FILE, schemaFolder.resolve(GEOMATICS_ATTRIBUTES_XSD), REPLACE_EXISTING);
 
         // execute
         testSuite.verifyGeomaticsAttributesXmlAgainstSchema();
@@ -59,8 +80,8 @@ public class VerifyGeomaticsAttributesXmlStructureTests extends MetadataTestFixt
     @Test
     public void verifyGeomaticsAttributesXmlAgainstSchema_XmlIsNotValid() throws IOException, SAXException {
         // setup
-        Files.copy(INVALID_FILE, metadataFolder.resolve("Geomatics_Attributes.xml"), REPLACE_EXISTING);
-        Files.copy(XSD_FILE, schemaFolder.resolve("Geomatics_Attributes.xsd"), REPLACE_EXISTING);
+        Files.copy(XML_INVALID, metadataFolder.resolve(GEOMATICS_ATTRIBUTES_XML), REPLACE_EXISTING);
+        Files.copy(XSD_FILE, schemaFolder.resolve(GEOMATICS_ATTRIBUTES_XSD), REPLACE_EXISTING);
 
         String expectedMessage = "Geomatics_Attributes.xml does not validate against its XML Schema file. " +
                 "Errors: cvc-complex-type.2.4.b: The content of element 'Geomatics_Attributes' is not complete. " +
@@ -72,16 +93,5 @@ public class VerifyGeomaticsAttributesXmlStructureTests extends MetadataTestFixt
 
         // execute
         testSuite.verifyGeomaticsAttributesXmlAgainstSchema();
-    }
-
-    @Test
-    public void verifyGeomaticsAttributesXmlAgainstSchema_GeomaticsAttributesXsdFileDoesNotExist() throws IOException, SAXException {
-        // setup
-        Files.createFile(metadataFolder.resolve(Paths.get("Geomatics_Attributes.xml")));
-        expectedException.expect(AssertionError.class);
-        expectedException.expectMessage("Metadata directory should contain Geomatics_Attributes.xsd file.");
-
-        // execute
-        testSuite.verifyGeomaticsAttributesXmlAgainstSchema(); // will not return an assertion error
     }
 }

--- a/src/test/java/org/opengis/cite/cdb10/metadataAndVersioning/VerifyVendorAttributesXmlStructureTests.java
+++ b/src/test/java/org/opengis/cite/cdb10/metadataAndVersioning/VerifyVendorAttributesXmlStructureTests.java
@@ -2,97 +2,18 @@ package org.opengis.cite.cdb10.metadataAndVersioning;
 
 import org.junit.Test;
 import org.testng.SkipException;
-import org.xml.sax.SAXException;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
-
-/**
- * Created by martin on 2016-09-09.
- */
 public class VerifyVendorAttributesXmlStructureTests extends MetadataTestFixture<VendorAttributesXmlStructureTests> {
-	
-	private static final String VENDOR_ATTRIBUTES_XSD = "Vendor_Attributes.xsd";
-	private static final String VENDOR_ATTRIBUTES_XML = "Vendor_Attributes.xml";
     
-	private final static Path XSD_FILE = SOURCE_DIRECTORY.resolve(Paths.get("schema", VENDOR_ATTRIBUTES_XSD));
-    private final static Path XML_LOCAL_XSD = SOURCE_DIRECTORY.resolve(Paths.get("valid", VENDOR_ATTRIBUTES_XML));
-    private final static Path XML_REMOTE_XSD_MISSING = SOURCE_DIRECTORY.resolve(Paths.get("invalid", "Vendor_AttributesRemoteMissing.xml"));
-    private final static Path XML_INVALID = SOURCE_DIRECTORY.resolve(Paths.get("invalid", "Vendor_AttributesInvalid.xml"));
-
     public VerifyVendorAttributesXmlStructureTests() { testSuite = new VendorAttributesXmlStructureTests(); }
     
     @Test
-    public void verifyVendorAttributesSchemaExists_XmlFileDoesNotExist() {
+    public void verifyVendorAttributesSchemaExists_Skips() {
     	// setup: No Vendor_Attributes.xml
     	expectedException.expect(SkipException.class);
-        expectedException.expectMessage("Will not check for Vendor Attributes Schema file as no Vendor Attributes XML file exists.");
+        expectedException.expectMessage("The OGC CDB 1.0 standard is unclear about whether Vendor_Attributes.xsd and Geomatics_Attributes.xsd, or Vector_Attributes.xsd should be used. Therefore this test is skipped.");
         
     	// execute
     	testSuite.verifyVendorAttributesSchemaExists();
-    }
-
-    @Test
-    public void verifyVendorAttributesSchemaExists_XsdDoesNotExist() throws IOException {
-        // setup
-        Files.copy(XML_LOCAL_XSD, metadataFolder.resolve(VENDOR_ATTRIBUTES_XML), REPLACE_EXISTING);
-        expectedException.expect(AssertionError.class);
-        expectedException.expectMessage("Schema could not be loaded from XML 'schemaLocation'.");
-
-        // execute
-        testSuite.verifyVendorAttributesSchemaExists();
-    }
-    
-    @Test
-    public void verifyVendorAttributesSchemaExists_RemoteXsdDoesNotExist() throws IOException {
-        // setup
-        Files.copy(XML_REMOTE_XSD_MISSING, metadataFolder.resolve(VENDOR_ATTRIBUTES_XML), REPLACE_EXISTING);
-        expectedException.expect(AssertionError.class);
-        expectedException.expectMessage("Schema could not be loaded from XML 'schemaLocation'.");
-
-        // execute
-        testSuite.verifyVendorAttributesSchemaExists();
-    }
-    
-    @Test
-    public void verifyVendorAttributesSchemaExists_XsdDoesExist() throws IOException {
-        // setup
-        Files.copy(XML_LOCAL_XSD, metadataFolder.resolve(VENDOR_ATTRIBUTES_XML), REPLACE_EXISTING);
-        Files.copy(XSD_FILE, schemaFolder.resolve(VENDOR_ATTRIBUTES_XSD), REPLACE_EXISTING);
-
-        // execute
-        testSuite.verifyVendorAttributesSchemaExists();
-    }
-
-    @Test
-    public void verifyVendorAttributesXmlAgainstSchema_XmlIsValid() throws IOException, SAXException {
-        // setup
-        Files.copy(XML_LOCAL_XSD, metadataFolder.resolve(VENDOR_ATTRIBUTES_XML), REPLACE_EXISTING);
-        Files.copy(XSD_FILE, schemaFolder.resolve(VENDOR_ATTRIBUTES_XSD), REPLACE_EXISTING);
-
-        // execute
-        testSuite.verifyVendorAttributesXmlAgainstSchema();
-    }
-
-    @Test
-    public void verifyVendorAttributesXmlAgainstSchema_XmlIsNotValid() throws IOException, SAXException {
-        // setup
-        Files.copy(XML_INVALID, metadataFolder.resolve(VENDOR_ATTRIBUTES_XML), REPLACE_EXISTING);
-        Files.copy(XSD_FILE, schemaFolder.resolve(VENDOR_ATTRIBUTES_XSD), REPLACE_EXISTING);
-
-        String expectedMessage = "Vendor_Attributes.xml does not validate against its XML Schema file. " +
-                "Errors: cvc-complex-type.2.4.b: The content of element 'Vendor_Attributes' is not complete. " +
-                "One of '{\"http://www.CDB-Spec.org/Schema/Version/3.2\":Example_Element_2}' is expected.";
-
-
-        expectedException.expect(AssertionError.class);
-        expectedException.expectMessage(expectedMessage);
-
-        // execute
-        testSuite.verifyVendorAttributesXmlAgainstSchema();
     }
 }

--- a/src/test/java/org/opengis/cite/cdb10/metadataAndVersioning/VerifyVendorAttributesXmlStructureTests.java
+++ b/src/test/java/org/opengis/cite/cdb10/metadataAndVersioning/VerifyVendorAttributesXmlStructureTests.java
@@ -27,45 +27,45 @@ public class VerifyVendorAttributesXmlStructureTests extends MetadataTestFixture
     public VerifyVendorAttributesXmlStructureTests() { testSuite = new VendorAttributesXmlStructureTests(); }
     
     @Test
-    public void verifyVendorAttributesXsdFileExists_XmlFileDoesNotExist() {
+    public void verifyVendorAttributesSchemaExists_XmlFileDoesNotExist() {
     	// setup: No Vendor_Attributes.xml
     	expectedException.expect(SkipException.class);
         expectedException.expectMessage("Will not check for Vendor Attributes Schema file as no Vendor Attributes XML file exists.");
         
     	// execute
-    	testSuite.verifyVendorAttributesXsdFileExists();
+    	testSuite.verifyVendorAttributesSchemaExists();
     }
 
     @Test
-    public void verifyVendorAttributesXsdFileExists_XsdDoesNotExist() throws IOException {
+    public void verifyVendorAttributesSchemaExists_XsdDoesNotExist() throws IOException {
         // setup
         Files.copy(XML_LOCAL_XSD, metadataFolder.resolve(VENDOR_ATTRIBUTES_XML), REPLACE_EXISTING);
         expectedException.expect(AssertionError.class);
         expectedException.expectMessage("Schema could not be loaded from XML 'schemaLocation'.");
 
         // execute
-        testSuite.verifyVendorAttributesXsdFileExists();
+        testSuite.verifyVendorAttributesSchemaExists();
     }
     
     @Test
-    public void verifyVendorAttributesXsdFileExists_RemoteXsdDoesNotExist() throws IOException {
+    public void verifyVendorAttributesSchemaExists_RemoteXsdDoesNotExist() throws IOException {
         // setup
         Files.copy(XML_REMOTE_XSD_MISSING, metadataFolder.resolve(VENDOR_ATTRIBUTES_XML), REPLACE_EXISTING);
         expectedException.expect(AssertionError.class);
         expectedException.expectMessage("Schema could not be loaded from XML 'schemaLocation'.");
 
         // execute
-        testSuite.verifyVendorAttributesXsdFileExists();
+        testSuite.verifyVendorAttributesSchemaExists();
     }
     
     @Test
-    public void verifyVendorAttributesXsdFileExists_XsdDoesExist() throws IOException {
+    public void verifyVendorAttributesSchemaExists_XsdDoesExist() throws IOException {
         // setup
         Files.copy(XML_LOCAL_XSD, metadataFolder.resolve(VENDOR_ATTRIBUTES_XML), REPLACE_EXISTING);
         Files.copy(XSD_FILE, schemaFolder.resolve(VENDOR_ATTRIBUTES_XSD), REPLACE_EXISTING);
 
         // execute
-        testSuite.verifyVendorAttributesXsdFileExists();
+        testSuite.verifyVendorAttributesSchemaExists();
     }
 
     @Test

--- a/src/test/resources/CDB/Metadata/Geomatics_Attributes.xml
+++ b/src/test/resources/CDB/Metadata/Geomatics_Attributes.xml
@@ -2,7 +2,7 @@
 <Geomatics_Attributes
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://www.CDB-Spec.org/Schema/Version/3.2"
-  xsi:schemaLocation="http://www.CDB-Spec.org/Schema/Version/3.2 Schema/Geomatics_Attributes.xsd">
+  xsi:schemaLocation="Schema/Geomatics_Attributes.xsd">
 
   <Example_Element_1></Example_Element_1>
   <Example_Element_2></Example_Element_2>

--- a/src/test/resources/CDB/Metadata/Vendor_Attributes.xml
+++ b/src/test/resources/CDB/Metadata/Vendor_Attributes.xml
@@ -2,7 +2,7 @@
 <Vendor_Attributes
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://www.CDB-Spec.org/Schema/Version/3.2"
-  xsi:schemaLocation="http://www.CDB-Spec.org/Schema/Version/3.2 Schema/Vendor_Attributes.xsd">
+  xsi:schemaLocation="Schema/Vendor_Attributes.xsd">
 
   <Example_Element_1></Example_Element_1>
   <Example_Element_2></Example_Element_2>


### PR DESCRIPTION
If a CDB has a "Geomatics_Attributes.xml" or "Vendor_Attributes.xml" file, then for each one it will be validated against the test suite rules. This pull request adds support for client-specified XML schema files, specified in the `schemaLocation` attribute. Closes #22.

If the schema location is an HTTP/HTTPS URL, then it is downloaded to disk and used for XML validation. If the file cannot be downloaded or is empty, then an error is raised.

If the schema location is a local file path, then that file will be used for XML validation.

I was able to start a local HTTP server with a sample XSD file available. Setting a `Geomatics_Attributes.xml` in a testing CDB to have a schema location at that local HTTP server will successfully issue an HTTP request and download the XSD file for validation. If there is a timeout or empty file, then the schema is marked as missing and an error will be raised.

### Other changes in this PR

`GeomaticsAttributesXml` and `VendorAttributesXml` now are sub-classes of the new `AttributesXml` class instead of the `MetadataXmlFile` class. This is to provide them with separate functionality to download remote schema files for validation. The validation classes for the other metadata XML files will continue to use the previous `MetadataXmlFile` parent to prevent tests from breaking.

The "Geomatics_Attributes.xml" and "Vendor_Attributes.xml" files in the sample embedded CDB have been updated to use local paths for their schema. The schema is also located in the embedded CDB, but should not be taken as authoritative; it is only an example of a custom schema.